### PR TITLE
Change unportable "python2" to "python"

### DIFF
--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2
+#!/usr/bin/env python
 
 # Copyright (c) 2012,2013 Michael Haggerty
 # Derived from contrib/hooks/post-receive-email, which is

--- a/git-multimail/migrate-mailhook-config
+++ b/git-multimail/migrate-mailhook-config
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2
+#!/usr/bin/env python
 
 """Migrate a post-receive-email configuration to be usable with git_multimail.py.
 

--- a/git-multimail/post-receive
+++ b/git-multimail/post-receive
@@ -1,4 +1,4 @@
-#! /usr/bin/env python2
+#!/usr/bin/env python
 
 """Example post-receive hook based on git-multimail.
 


### PR DESCRIPTION
Invoking just "python2" doesn't work on Debian-based systems, change
it to "python" which should work everywhere.
