### PR TITLE
Updated post-receive example

### DIFF
--- a/git-multimail/post-receive
+++ b/git-multimail/post-receive
@@ -59,7 +59,7 @@ environment = git_multimail.GenericEnvironment(config)
 
 # Choose the method of sending emails.  OutputMailer is intended only
 # for testing; it writes the emails to the specified file stream.
-mailer = git_multimail.SendMailer(environment.get_sender())
+mailer = git_multimail.SendMailer(environment.sender)
 #mailer = git_multimail.OutputMailer(sys.stdout)
 
 # Read changes from stdin and send notification emails:


### PR DESCRIPTION
Was renamed in 1a1cafdcf81a1211c77227c1625254e9f1c541f9, but the post-receive was not updated
