### PR TITLE
Fix git log arguments to be backwards compatible with older versions of git

### DIFF
--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -578,7 +578,7 @@ class Revision(Change):
 
         return read_lines(
             [
-                'git', 'log', '--find-renames', '--find-copies',
+                'git', 'log', '-C',
                  '--stat', '--patch', '--cc',
                 '-1', self.rev.sha1,
                 ],


### PR DESCRIPTION
older versions of git log (e.g. 1.7.2.5 on Debian Squeeze) do not support --find-renames or --find-copies. So these should be replaced with -M and -C. But, -M is implied by -C so -M is removed
