### PR TITLE
call 'git log -p', not 'git log --patch' (unavailable in old Git)

### DIFF
--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -579,7 +579,7 @@ class Revision(Change):
         return read_lines(
             [
                 'git', 'log', '-C',
-                 '--stat', '--patch', '--cc',
+                 '--stat', '-p', '--cc',
                 '-1', self.rev.sha1,
                 ],
             keepends=True,


### PR DESCRIPTION
'--patch' was introduced as a synonym for '-p' in Git v1.7.2.
