### PR TITLE
Documentation readability improvements

### DIFF
--- a/git-multimail/README
+++ b/git-multimail/README
@@ -55,6 +55,9 @@ By default, reference change emails have their "Reply-To" field set to
 the person who pushed the change, and commit emails have their
 "Reply-To" field set to the author of the commit.
 
+3. Output one "announce" mail for each new annotated tag, including
+   information about the tag and optionally a shortlog describing the
+   changes since the previous tag.
 
 Invocation
 ----------


### PR DESCRIPTION
The list of config options starts being a bit long.

This branch tries to make it more readable and easier to go through, by making the link between the 1. / 2. (and now 3.) enumeration at the top and the list of options.

Perhaps it's time to introduce sections/subsections in the list too, but I didn't do that.
