### PR TITLE
Various potential improvements (especially for non hook usage)

### DIFF
--- a/git-multimail/README
+++ b/git-multimail/README
@@ -249,6 +249,13 @@ multimailhook.emailMaxLineLength
     lines, the diffs are probably unreadable anyway.  To disable line
     truncation, set this option to 0.
 
+multimailhook.maxPatchNb
+
+    The maximum number of commit email to send for a given change.
+    When the number of patches is larger that this value, only the
+    summary refchange email is sent. This can avoid accidental
+    mailbombing.  The default is 500.
+
 multimailhook.emailStrictUTF8
 
     If this boolean option is set to "true", then the main part of the

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -1296,6 +1296,7 @@ class Environment(object):
         self.announce_show_shortlog = False
         self.maxlines = None
         self.maxlinelength = 500
+        self.maxpatchnb = 500
         self.strict_utf8 = True
         self.diffopts = ['--stat', '--summary', '--find-copies-harder']
         self.logopts = []
@@ -1437,6 +1438,10 @@ class ConfigEnvironment(Environment):
         maxlinelength = self.config.get('emailmaxlinelength', default=None)
         if maxlinelength is not None:
             self.maxlinelength = int(maxlinelength)
+
+        maxpatchnb = self.config.get('maxpatchnb', default=None)
+        if maxpatchnb is not None:
+            self.maxpatchnb = int(maxpatchnb)
 
         strict_utf8 = self.config.get_bool('emailstrictutf8', default=None)
         if strict_utf8 is not None:
@@ -1732,6 +1737,16 @@ class Push(object):
                 if sha1 in unhandled_sha1s:
                     sha1s.append(sha1)
                     unhandled_sha1s.remove(sha1)
+
+            maxnb = change.environment.maxpatchnb
+            if maxnb and len(sha1s) > maxnb:
+                sys.stderr.write(
+                    '*** Too many new commits (%d), not sending emails.\n' % len(sha1s)
+                    + '*** Try setting multimailhook.maxPatchNb to a greater value\n'
+                    + '*** Currently, multimailhook.maxPatchNb=%d\n' % maxnb
+                    )
+                return
+
             for (num, sha1) in enumerate(sha1s):
                 rev = Revision(change, GitObject(sha1), num=num+1, tot=len(sha1s))
                 if rev.recipients:


### PR DESCRIPTION
I played a bit with git_multimail in a somewhat different setup: for repositories that do not have email-sending hooks set up, I have a cron job that runs nightly, calls "git fetch" in each of my local repositories, and emails me patches brought by this "git fetch" command. My previous version was using git format-patch and git send-email to do this, but git_multimail should be a better way to do this.

The patches in this merge request make git_multimail feature complete with the email-sending part of my old dirty shell-script.

This merge request is a set of mostly unrelated commits (the first 2 already appear in other requests, but I can't rebase without conflict), I'm sending one big request to get your opinion on it. Depending on how you like them, I can resubmit requests for individual patches.

The --reflog option was an experiment, I'm not actually using it, but I thought it could make sense.

read_git_output and read_git_lines are just cleanups.

multimailhook.maxPatchNb is the really useful patch to me. I've already been mailbombed by my own script once, I'll try not to reproduce ;-).
