### PR TITLE
Introduce skipRefs and onlyRefs to limit the scope of the hook

### DIFF
--- a/git-multimail/README
+++ b/git-multimail/README
@@ -343,6 +343,29 @@ multimailhook.replyToRefchange
     - The value "none", in which case the Reply-To: field will be
       omitted.
 
+multimailhook.skipRefs
+multimailhook.onlyRefs
+
+    List of reference names glob patterns to skip or to restrict
+    to when sending emails.  A reference is skept if its name matches
+    one of the patterns in skipRefs, or if onlyRefs is non-empty and
+    contain no pattern matching it.  Both variables apply to full
+    reference names (refs/heads/some-branch, not just some-branch).
+    For example, to send emails only for changes on branches "master"
+    and "maint", use:
+
+      [multimailhook]
+          onlyRefs = refs/heads/master refs/heads/maint
+
+   To send emails for all changes, except in branch whose name start
+   with "devel-", use:
+
+      [multimailhook]
+          onlyRefs = refs/heads/devel-*
+
+   The syntax of each glob pattern is the one of Python's fnmatch
+   module.
+
 
 Email filtering
 ---------------

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -1677,10 +1677,10 @@ class ConfigEnvironment(Environment):
             self.reply_to_refchange = reply_to_refchange
 
         self.skiprefs = []
-        for l in self.config.get_all('skipRefs'):
+        for l in self.config.get_all('skipRefs') or []:
             self.skiprefs.extend(l.split())
         self.onlyrefs = []
-        for l in self.config.get_all('onlyRefs'):
+        for l in self.config.get_all('onlyRefs') or []:
             self.onlyrefs.extend(l.split())
 
     def _get_recipients(self, *names):


### PR DESCRIPTION
We may want to extend this to some glob or regexp matching in the future,
but for now, this fits my need perfectly so let's keep it simple.