### PR TITLE
[RFC] Introduce multimailhook.useRepoPath to show path instead of repo name

### DIFF
--- a/git-multimail/README
+++ b/git-multimail/README
@@ -161,6 +161,11 @@ multimailhook.repoName
     from the repository path, or to use $GL_REPO for gitolite
     repositories.
 
+multimailhook.useRepoPath
+
+    If set to true, then use the absolute path to the repository
+    instead of its name.
+
 multimailhook.mailinglist
 
     The list of email addresses to which notification emails should be


### PR DESCRIPTION
Although the common practice is that the repository basename gives a
meaningful name, it can happen also to have directories organized like:

project1/git/
project2/git/
project3/git/

In this case, the default shortname will be [git] for all repositories.
This new option can be set in a users's ~/.gitconfig to have all
notification emails contain the full path to the repositories.

My use-case is a cron job that does essentially "git fetch && git multimail" in each of my home's repository, and 90% of my repositories are just named "git" so currently the email subjects are helpless.

I'm not 100% satisfied with the result, as the path can be long and not well suited for email subject. In my original script, I was generating email subjects like

 [git] new commits in /path/to/repo

The repo path was at the end, so it was OK if my mailer truncated it. Still, it's much better for me than the existing git-multimail. Maybe we should distinguish a "shortname" (in the email subject line) and a "name" (in the email body). Or maybe the Subject line should be configurable from Git's config file.

Let me know what you think about this change and I can modify it accordingly.
