### PR TITLE
Make repo_path available to template strings

### DIFF
--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -1386,6 +1386,10 @@ class Environment(object):
 
             A short name for the repository, for display purposes.
 
+        repo_path
+
+            Absolute path to the Git repository.
+
         emailprefix
 
             A string that will be prefixed to every email's subject.
@@ -1493,6 +1497,7 @@ class Environment(object):
         'pusher',
         'pusher_email',
         'fromaddr',
+        'repo_path',
         ]
 
     def __init__(self):
@@ -1516,8 +1521,16 @@ class Environment(object):
         self.refchange_showlog = False
         self.reply_to_refchange = 'pusher'
         self.reply_to_commit = 'author'
+        self.repo_path = self.get_repo_path()
 
         self._values = None
+
+    def get_repo_path(self):
+        if read_git_output(['rev-parse', '--is-bare-repository']) == 'true':
+            path = GIT_DIR
+        else:
+            path = read_git_output(['rev-parse', '--show-toplevel'])
+        return os.path.abspath(path)
 
     def get_values(self):
         """Return a dictionary {keyword : expansion} for this Environment.


### PR DESCRIPTION
It can be convenient to include the absolute path to the Git repository
in the email subject or body. Users can override email subject or body by
overriding the template strings. This patch allows the user to use
%(repo_path)s in the templates.

Makes pull request #19 partly obsolete.
