### PR TITLE
Add "References" as well as the "In-Reply-To" header

### DIFF
--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -185,6 +185,7 @@ Content-Type: text/plain; charset=utf-8
 From: %(sender)s
 Reply-To: %(author)s
 In-Reply-To: %(reply_to_msgid)s
+References: %(reply_to_msgid)s
 X-Git-Repo: %(repo_shortname)s
 X-Git-Refname: %(refname)s
 X-Git-Reftype: %(refname_type)s


### PR DESCRIPTION
See http://www.jwz.org/doc/threading.html for details. Some co-workers
of mine have a mail client that doesn't properly thread without
this. Since we're only referencing one message its value can just be
the same as "In-Reply-To".
