### PR TITLE
Several changes useful to write wrappers in Python

### DIFF
--- a/git-multimail/README
+++ b/git-multimail/README
@@ -564,5 +564,6 @@ Footnotes
     seen does not work when it is used as an "update" script.  In
     particular, no notification email will be generated for a new
     commit that is added to multiple references in the same push.
+    A workaround is to use --force-send to force sending the emails.
 
 [3] https://github.com/sitaramc/gitolite


### PR DESCRIPTION
EDIT: one commit was merged already, I dropped another. Only --force-send remains (it used to be multimailhook.dontComputeNewRevs but I ended up thinking that a CLI option was more convenient).

The 3 commits are mostly independent. You may want to cherry-pick only some of them.

The "normalize changed ref names in computation of exclude revspec" was a failed attempt to avoid having to rely on "multimailhook.dontComputeNewRevs". I don't really need it, but it costs almost nothing so I thought it could be useful to someone.

The other two are significant improvements for me.