### PR TITLE
multimail: remove redundant error handling

### DIFF
--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -657,13 +657,9 @@ class Revision(Change):
     def _compute_values(self):
         values = Change._compute_values(self)
 
-        # First line of commit message:
-        try:
-            oneline = read_git_output(
-                ['log', '--format=%s', '--no-walk', self.rev.sha1]
-                )
-        except CommandError:
-            oneline = self.rev.sha1
+        oneline = read_git_output(
+            ['log', '--format=%s', '--no-walk', self.rev.sha1]
+            )
 
         values['rev'] = self.rev.sha1
         values['rev_short'] = self.rev.short


### PR DESCRIPTION
$ git log --format=%s --no-walk $SHA1

can never fail unless $SHA1 is an invalid SHA-1 (which is again not
possible from preceding code).  Strip this redundant error handling.

Signed-off-by: Ramkumar Ramachandra artagnon@gmail.com
