### PR TITLE
added an option commitDiffOpts to customize logs for revisions

### DIFF
--- a/git-multimail/README
+++ b/git-multimail/README
@@ -344,6 +344,25 @@ multimailhook.logOpts
       [multimailhook]
               logopts = --pretty=format:\"%h %aN <%aE>%n%s%n%n%b%n\"
 
+multimailhook.commitLogOpts
+
+    Options passed to "git log" to generate additional info for
+    revision change emails.
+    For example, adding --ignore-all-spaces will suppress whitespace
+    changes. The default is empty.
+
+    Shell quoting is allowed; for example, a log format that contains
+    spaces can be specified using something like:
+
+      git config multimailhook.commitlogopts '--pretty=format:"%h %aN <%aE>%n%s%n%n%b%n"'
+
+    If you want to set this by editing your configuration file
+    directly, remember that Git requires double-quotes to be escaped
+    (see git-config(1) for more information):
+
+      [multimailhook]
+              commitlogopts = --pretty=format:\"%h %aN <%aE>%n%s%n%n%b%n\"
+
 multimailhook.emailDomain
 
     Domain name appended to the username of the person doing the push

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -718,11 +718,9 @@ class Revision(Change):
         """Show this revision."""
 
         return read_git_lines(
-            [
-                'log', '-C',
-                 '--stat', '-p', '--cc',
-                '-1', self.rev.sha1,
-                ],
+            [ 'log', '-C', '--stat', '-p', '--cc', '-1', ] +
+            self.environment.commitlogopts +
+            [ self.rev.sha1, ],
             keepends=True,
             )
 
@@ -826,6 +824,7 @@ class ReferenceChange(Change):
         self.msgid = make_msgid()
         self.diffopts = environment.diffopts
         self.logopts = environment.logopts
+        self.commitlogopts = environment.commitlogopts
         self.showlog = environment.refchange_showlog
 
     def _compute_values(self):
@@ -1521,6 +1520,12 @@ class Environment(object):
             'git log' when generating the detailed log for a set of
             commits (see refchange_showlog)
 
+        commitlogopts (list of strings)
+
+            The options that should be passed to 'git log' for each
+            commit mail. The value should be a list of strings
+            representing words to be passed to the command.
+
     """
 
     REPO_NAME_RE = re.compile(r'^(?P<name>.+?)(?:\.git)$')
@@ -1532,6 +1537,7 @@ class Environment(object):
         self.diffopts = ['--stat', '--summary', '--find-copies-harder']
         self.logopts = []
         self.refchange_showlog = False
+        self.commitlogopts = []
 
         self.COMPUTED_KEYS = [
             'administrator',
@@ -1697,6 +1703,10 @@ class ConfigOptionsEnvironmentMixin(ConfigEnvironmentMixin):
         logopts = config.get('logopts')
         if logopts is not None:
             self.logopts = shlex.split(logopts)
+
+        commitlogopts = config.get('commitlogopts')
+        if commitlogopts is not None:
+            self.commitlogopts = shlex.split(commitlogopts)
 
         reply_to = config.get('replyTo')
         self.__reply_to_refchange = config.get('replyToRefchange', default=reply_to)


### PR DESCRIPTION
Added in the same way as logOpts/diffOpts. Default is empty.
Useful to ignore whitespace changes, or to change formatting
of commit log messages
