### PR TITLE
If a mailing list setting is missing, just don't send the mail.

### DIFF
--- a/git-multimail/README
+++ b/git-multimail/README
@@ -186,7 +186,8 @@ multimailhook.refchangeList
     separated by commas.  This configuration option can be
     multivalued.  The default is the value in
     multimailhook.mailingList.  Set this value to the empty string to
-    prevent reference change emails from being sent.
+    prevent reference change emails from being sent even if
+    multimailhook.mailingList is set.
 
 multimailhook.announceList
 
@@ -195,7 +196,8 @@ multimailhook.announceList
     commas.  This configuration option can be multivalued.  The
     default is the value in multimailhook.refchangeList or
     multimailhook.mailingList.  Set this value to the empty string to
-    prevent annotated tag announcement emails from being sent.
+    prevent annotated tag announcement emails from being sent even if
+    one of the other values is set.
 
 multimailhook.commitList
 
@@ -204,7 +206,8 @@ multimailhook.commitList
     commas.  This configuration option can be multivalued.  The
     default is the value in multimailhook.mailingList.  Set this value
     to the empty string to prevent notification emails about
-    individual commits from being sent.
+    individual commits from being sent even if
+    multimailhook.mailingList is set.
 
 multimailhook.announceShortlog
 

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -1939,6 +1939,10 @@ class StaticRecipientsEnvironmentMixin(Environment):
         # actual *contents* of the change being reported, we only
         # choose based on the *type* of the change.  Therefore we can
         # compute them once and for all:
+        if not (refchange_recipients
+                or announce_recipients
+                or revision_recipients):
+            raise ConfigurationException('No email recipients configured!')
         self.__refchange_recipients = refchange_recipients
         self.__announce_recipients = announce_recipients
         self.__revision_recipients = revision_recipients
@@ -1989,17 +1993,8 @@ class ConfigRecipientsEnvironmentMixin(
             retval = config.get_recipients(name)
             if retval is not None:
                 return retval
-        if len(names) == 1:
-            hint = 'Please set "%s.%s"' % (config.section, name)
         else:
-            hint = (
-                'Please set one of the following:\n    "%s"'
-                % ('"\n    "'.join('%s.%s' % (config.section, name) for name in names))
-                )
-
-        raise ConfigurationException(
-            'The list of recipients for %s is not configured.\n%s' % (names[0], hint)
-            )
+            return ''
 
 
 class ProjectdescEnvironmentMixin(Environment):


### PR DESCRIPTION
Instead of being really insistent that all mailing list values are configured, just treat unset values as "don't send this kind of email".  In any case, the user will see a warning that no emails were sent, so an accidental misconfiguration shouldn't go unnoticed for long.

This change was suggested by @moy [here](https://github.com/mhagger/git-multimail/issues/39#issuecomment-27630867).
