### PR TITLE
Emit single pushed commit as just a single email

### DIFF
--- a/git-multimail/CHANGES
+++ b/git-multimail/CHANGES
@@ -1,3 +1,9 @@
+Release ?.?.?
+=============
+
+* When a single commit is pushed, omit the reference changed email.
+
+
 Release 1.0.0
 =============
 

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -874,6 +874,10 @@ class ReferenceChange(Change):
         self.commitlogopts = environment.commitlogopts
         self.showlog = environment.refchange_showlog
 
+        self.header_template = REFCHANGE_HEADER_TEMPLATE
+        self.intro_template = REFCHANGE_INTRO_TEMPLATE
+        self.footer_template = FOOTER_TEMPLATE
+
     def _compute_values(self):
         values = Change._compute_values(self)
 
@@ -940,12 +944,12 @@ class ReferenceChange(Change):
             extra_values['subject'] = self.get_subject()
 
         for line in self.expand_header_lines(
-                REFCHANGE_HEADER_TEMPLATE, **extra_values
+                self.header_template, **extra_values
                 ):
             yield line
 
     def generate_email_intro(self):
-        for line in self.expand_lines(REFCHANGE_INTRO_TEMPLATE):
+        for line in self.expand_lines(self.intro_template):
             yield line
 
     def generate_email_body(self, push):
@@ -966,7 +970,7 @@ class ReferenceChange(Change):
             yield line
 
     def generate_email_footer(self):
-        return self.expand_lines(FOOTER_TEMPLATE)
+        return self.expand_lines(self.footer_template)
 
     def generate_revision_change_log(self, new_commits_list):
         if self.showlog:

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -2354,21 +2354,30 @@ class Push(object):
             try:
                 # If this change is a reference update that doesn't discard
                 # any commits...
-                if change.change_type == 'update' \
-                and [change.old.sha1] == read_git_lines(['merge-base',
-                       change.old.sha1, change.new.sha1]):
+                if (
+                        change.change_type == 'update'
+                        and read_git_lines(
+                            ['merge-base', change.old.sha1, change.new.sha1]
+                            ) == [change.old.sha1]
+                        ):
                     # Get the new commits introduced by the push
-                    new_commits = read_git_lines(['log', '-3', '--format=%H %P',
-                       '%s..%s' % (change.old.sha1, change.new.sha1)])
+                    new_commits = read_git_lines(
+                        [
+                            'log', '-3', '--format=%H %P',
+                            '%s..%s' % (change.old.sha1, change.new.sha1),
+                            ]
+                        )
                     # If the newest commit is a merge, ignore it
                     parents = new_commits[0].split()[1:]
                     if len(parents) > 1:
                         new_commits = new_commits[1:]
                     # If there's exactly one non-merge commit introduced by
                     # this update, turn off the reference summary email
-                    if len(new_commits) == 1 and \
-                       len(new_commits[0].split())==2 and \
-                       new_commits[0].split()[0] in unhandled_sha1s:
+                    if (
+                            len(new_commits) == 1
+                            and len(new_commits[0].split()) == 2
+                            and new_commits[0].split()[0] in unhandled_sha1s
+                            ):
                         send_reference_summary_emails = False
             except CommandError:
                 # Cannot determine number of commits in old..new or new..old;

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -1197,10 +1197,15 @@ class BranchChange(ReferenceChange):
                     '%s..%s' % (self.old.sha1, self.new.sha1),
                     ]
                 )
+
+            if not new_commits:
+                return False
+
             # If the newest commit is a merge, ignore it
             parents = new_commits[0].split()[1:]
             if len(parents) > 1:
                 new_commits = new_commits[1:]
+
             # If there's exactly one non-merge commit introduced by
             # this update, turn off the reference summary email
             return (

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -1303,10 +1303,15 @@ class BranchChange(ReferenceChange):
                 ):
                 return None
 
+            # We do not want to combine revision and refchange emails if
+            # those go to separate locations.
+            rev = Revision(self, GitObject(new_commits[0][0]), 1, tot)
+            if rev.recipients != self.recipients:
+                return None
+
             # We can combine the refchange and one new revision emails
             # into one.  Return the Revision that a combined email should
             # be sent about.
-            rev = Revision(self, GitObject(new_commits[0][0]), 1, tot)
             return rev
         except CommandError:
             # Cannot determine number of commits in old..new or new..old;

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -899,16 +899,33 @@ class ReferenceChange(Change):
 
         return values
 
-    def adds_single_commit(self, known_added_sha1s):
-        """Return True iff this change adds a single commit to a branch.
+    def send_single_combined_email(self, known_added_sha1s):
+        """Determine if a combined refchange/revision email should be sent
 
-        Such changes are eligible for having their ReferenceChange
-        emails omitted and being reported only via a Revision
-        email.
+        If there is only a single new (non-merge) commit added by a
+        change, it is useful to combine the ReferenceChange and
+        Revision emails into one.  In such a case, return the single
+        revision; otherwise, return None.
 
         This method is overridden in BranchChange."""
 
-        return False
+        return None
+
+    def generate_combined_email(self, push, revision, body_filter=None, extra_header_values={}):
+        """Generate an email describing this change AND specified revision.
+
+        Iterate over the lines (including the header lines) of an
+        email describing this change.  If body_filter is not None,
+        then use it to filter the lines that are intended for the
+        email body.
+
+        The extra_header_values field is received as a dict and not as
+        **kwargs, to allow passing other keyword arguments in the
+        future (e.g. passing extra values to generate_email_intro()
+
+        This method is overridden in BranchChange."""
+
+        raise NotImplementedError
 
     def get_subject(self):
         template = {
@@ -1178,17 +1195,33 @@ class BranchChange(ReferenceChange):
             )
         self.recipients = environment.get_refchange_recipients(self)
 
-    def adds_single_commit(self, known_added_sha1s):
+    def send_single_combined_email(self, known_added_sha1s):
+        # In the sadly-all-too-frequent usecase of people pushing only
+        # one of their commits at a time to a repository, users feel
+        # the reference change summary emails are noise rather than
+        # important signal.  This is because, in this particular
+        # usecase, there is a reference change summary email for each
+        # new commit, and all these summaries do is point out that
+        # there is one new commit (which can readily be inferred by
+        # the existence of the individual revision email that is also
+        # sent).  In such cases, our users prefer there to be a combined
+        # reference change summary/new revision email.
+        #
+        # So, if the change is an update and it doesn't discard any
+        # commits, and it adds exactly one non-merge commit (gerrit
+        # forces a workflow where every commit is individually merged
+        # and the git-multimail hook fired off for just this one
+        # change), then we send a combined refchange/revision email.
         try:
             # If this change is a reference update that doesn't discard
             # any commits...
             if self.change_type != 'update':
-                return False
+                return None
 
             if read_git_lines(
                     ['merge-base', self.old.sha1, self.new.sha1]
                     ) != [self.old.sha1]:
-                return False
+                return None
 
             # Check if this update introduced exactly one non-merge
             # commit:
@@ -1212,21 +1245,36 @@ class BranchChange(ReferenceChange):
                 ]
 
             if not new_commits:
-                return False
+                return None
 
-            # If the newest commit is a merge, ignore it
+            tot = len(new_commits)
             if len(new_commits[0][1]) > 1:
                 del new_commits[0]
 
-            return (
+            # Our primary check: we can't combine if more than one commit
+            # is introduced.  We also currently only combine if the new
+            # commit is a non-merge commit, though it may make sense to
+            # combine if it is a merge as well.
+            if not (
                 len(new_commits) == 1
                 and len(new_commits[0][1]) == 1
                 and new_commits[0][0] in known_added_sha1s
-                )
+                ):
+                return None
+
+            # We can combine the refchange and one new revision emails
+            # into one.  Return the Revision that a combined email should
+            # be sent about.
+            rev = Revision(self, GitObject(new_commits[0][0]), 1, tot)
+            return rev
         except CommandError:
             # Cannot determine number of commits in old..new or new..old;
-            # don't turn off reference summary emails:
-            return False
+            # don't combine reference/revision emails:
+            return None
+
+    def generate_combined_email(self, push, revision, body_filter=None, extra_header_values={}):
+        # FIXME: Need to send a combined email, not just a revision email
+        revision.generate_email(push, body_filter, extra_header_values)
 
 
 class AnnotatedTagChange(ReferenceChange):
@@ -2395,6 +2443,12 @@ class Push(object):
         unhandled_sha1s = set(self.get_new_commits())
         send_date = IncrementalDateTime()
         for change in self.changes:
+            sha1s = []
+            for sha1 in reversed(list(self.get_new_commits(change))):
+                if sha1 in unhandled_sha1s:
+                    sha1s.append(sha1)
+                    unhandled_sha1s.remove(sha1)
+
             # Check if we've got anyone to send to
             if not change.recipients:
                 sys.stderr.write(
@@ -2402,39 +2456,24 @@ class Push(object):
                     '*** for %r update %s->%s\n'
                     % (change.refname, change.old.sha1, change.new.sha1,)
                     )
-            elif change.adds_single_commit(unhandled_sha1s):
-                # In the sadly-all-too-frequent usecase of people
-                # pushing only one of their commits at a time to a
-                # repository, users feel the reference change summary
-                # emails are noise rather than important signal.  This
-                # is because, in this particular usecase, there is a
-                # reference change summary email for each new commit,
-                # and all these summaries do is point out that there
-                # is one new commit (which can readily be inferred by
-                # the existence of the individual revision email that
-                # is also sent).  In such cases, our users prefer
-                # there to be no push summary email.
-                #
-                # So, if the change is an update and it doesn't
-                # discard any commits, and it adds exactly one
-                # non-merge commit (gerrit forces a workflow where
-                # every commit is individually merged and the
-                # git-multimail hook fired off for just this one
-                # change), then we turn the push summary email off.
-                pass
             else:
                 sys.stderr.write('Sending notification emails to: %s\n' % (change.recipients,))
                 extra_values = {'send_date': send_date.next()}
-                mailer.send(
-                    change.generate_email(self, body_filter, extra_values),
-                    change.recipients,
-                    )
 
-            sha1s = []
-            for sha1 in reversed(list(self.get_new_commits(change))):
-                if sha1 in unhandled_sha1s:
-                    sha1s.append(sha1)
-                    unhandled_sha1s.remove(sha1)
+                rev = change.send_single_combined_email(sha1s)
+                if rev:
+                    mailer.send(
+                        change.generate_combined_email(self, rev, body_filter, extra_values),
+                        rev.recipients,
+                    )
+                    # This change is now fully handled; no need to handle
+                    # individual revisions any further.
+                    continue
+                else:
+                    mailer.send(
+                        change.generate_email(self, body_filter, extra_values),
+                        change.recipients,
+                    )
 
             max_emails = change.environment.maxcommitemails
             if max_emails and len(sha1s) > max_emails:

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -899,6 +899,17 @@ class ReferenceChange(Change):
 
         return values
 
+    def adds_single_commit(self, known_added_sha1s):
+        """Return True iff this change adds a single commit to a branch.
+
+        Such changes are eligible for having their ReferenceChange
+        emails omitted and being reported only via a Revision
+        email.
+
+        This method is overridden in BranchChange."""
+
+        return False
+
     def get_subject(self):
         template = {
             'create': REF_CREATED_SUBJECT_TEMPLATE,
@@ -1166,6 +1177,39 @@ class BranchChange(ReferenceChange):
             old=old, new=new, rev=rev,
             )
         self.recipients = environment.get_refchange_recipients(self)
+
+    def adds_single_commit(self, known_added_sha1s):
+        try:
+            # If this change is a reference update that doesn't discard
+            # any commits...
+            if (
+                    self.change_type == 'update'
+                    and read_git_lines(
+                        ['merge-base', self.old.sha1, self.new.sha1]
+                        ) == [self.old.sha1]
+                    ):
+                # Get the new commits introduced by the push
+                new_commits = read_git_lines(
+                    [
+                        'log', '-3', '--format=%H %P',
+                        '%s..%s' % (self.old.sha1, self.new.sha1),
+                        ]
+                    )
+                # If the newest commit is a merge, ignore it
+                parents = new_commits[0].split()[1:]
+                if len(parents) > 1:
+                    new_commits = new_commits[1:]
+                # If there's exactly one non-merge commit introduced by
+                # this update, turn off the reference summary email
+                return (
+                    len(new_commits) == 1
+                    and len(new_commits[0].split()) == 2
+                    and new_commits[0].split()[0] in known_added_sha1s
+                    )
+        except CommandError:
+            # Cannot determine number of commits in old..new or new..old;
+            # don't turn off reference summary emails:
+            return False
 
 
 class AnnotatedTagChange(ReferenceChange):
@@ -2334,56 +2378,6 @@ class Push(object):
         unhandled_sha1s = set(self.get_new_commits())
         send_date = IncrementalDateTime()
         for change in self.changes:
-            # In the sadly-all-too-frequent usecase of people pushing only
-            # one of their commits at a time to a repository, users feel
-            # the reference change summary emails are noise rather than
-            # important signal.  This is because, in this particular
-            # usecase, there is a reference change summary email for each
-            # new commit, and all these summaries do is point out that
-            # there is one new commit (which can readily be inferred by the
-            # existence of the individual revision email that is also
-            # sent).  In such cases, our users prefer there to be no push
-            # summary email.
-            #
-            # So, if the change is an update and it doesn't discard any
-            # commits, and it adds exactly one non-merge commit (gerrit forces
-            # a workflow where every commit is individually merged and the
-            # git-multimail hook fired off for just this one change), then we
-            # turn the push summary email off.
-            send_reference_summary_emails = True
-            try:
-                # If this change is a reference update that doesn't discard
-                # any commits...
-                if (
-                        change.change_type == 'update'
-                        and read_git_lines(
-                            ['merge-base', change.old.sha1, change.new.sha1]
-                            ) == [change.old.sha1]
-                        ):
-                    # Get the new commits introduced by the push
-                    new_commits = read_git_lines(
-                        [
-                            'log', '-3', '--format=%H %P',
-                            '%s..%s' % (change.old.sha1, change.new.sha1),
-                            ]
-                        )
-                    # If the newest commit is a merge, ignore it
-                    parents = new_commits[0].split()[1:]
-                    if len(parents) > 1:
-                        new_commits = new_commits[1:]
-                    # If there's exactly one non-merge commit introduced by
-                    # this update, turn off the reference summary email
-                    if (
-                            len(new_commits) == 1
-                            and len(new_commits[0].split()) == 2
-                            and new_commits[0].split()[0] in unhandled_sha1s
-                            ):
-                        send_reference_summary_emails = False
-            except CommandError:
-                # Cannot determine number of commits in old..new or new..old;
-                # don't turn off reference summary emails
-                pass
-
             # Check if we've got anyone to send to
             if not change.recipients:
                 sys.stderr.write(
@@ -2391,8 +2385,27 @@ class Push(object):
                     '*** for %r update %s->%s\n'
                     % (change.refname, change.old.sha1, change.new.sha1,)
                     )
-                send_reference_summary_emails = False
-            if send_reference_summary_emails:
+            elif change.adds_single_commit(unhandled_sha1s):
+                # In the sadly-all-too-frequent usecase of people
+                # pushing only one of their commits at a time to a
+                # repository, users feel the reference change summary
+                # emails are noise rather than important signal.  This
+                # is because, in this particular usecase, there is a
+                # reference change summary email for each new commit,
+                # and all these summaries do is point out that there
+                # is one new commit (which can readily be inferred by
+                # the existence of the individual revision email that
+                # is also sent).  In such cases, our users prefer
+                # there to be no push summary email.
+                #
+                # So, if the change is an update and it doesn't
+                # discard any commits, and it adds exactly one
+                # non-merge commit (gerrit forces a workflow where
+                # every commit is individually merged and the
+                # git-multimail hook fired off for just this one
+                # change), then we turn the push summary email off.
+                pass
+            else:
                 sys.stderr.write('Sending notification emails to: %s\n' % (change.recipients,))
                 extra_values = {'send_date': send_date.next()}
                 mailer.send(

--- a/notes.txt
+++ b/notes.txt
@@ -75,11 +75,6 @@ Ideas for the future
   the same commit (e.g., describe them all in a single email rather
   than one email per tag).
 
-* If a single commit is pushed, emit it as a single email (not
-  refchanged + commit).
-
-  Suggested by: Ævar Arnfjörð Bjarmason <avarab@gmail.com>
-
 * Allow people to subscribe to changes only to particular files.
 
   Suggested by: Ævar Arnfjörð Bjarmason <avarab@gmail.com>

--- a/t/generate-test-emails
+++ b/t/generate-test-emails
@@ -75,6 +75,7 @@ test_rewind refs/heads/master refs/heads/feature
 test_rewind refs/heads/master refs/heads/master^
 
 test_update refs/heads/release refs/heads/release^^^^
+test_update refs/heads/release refs/heads/release^
 test_rewind refs/heads/release refs/heads/release^^
 
 test_create refs/heads/feature

--- a/t/generate-test-emails
+++ b/t/generate-test-emails
@@ -75,7 +75,9 @@ test_rewind refs/heads/master refs/heads/feature
 test_rewind refs/heads/master refs/heads/master^
 
 test_update refs/heads/release refs/heads/release^^^^
+git config multimailhook.refchangelist 'Commit List <commitlist@example.com>'
 test_update refs/heads/release refs/heads/release^
+git config multimailhook.refchangelist 'Refchange List <refchangelist@example.com>'
 test_rewind refs/heads/release refs/heads/release^^
 
 test_create refs/heads/feature

--- a/t/multimail.expect
+++ b/t/multimail.expect
@@ -1053,6 +1053,52 @@ To stop receiving notification emails like this one, please contact
 Administrator <administrator@example.com>.
 EOF
 ######################################################################
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: Commit List <commitlist@example.com>
+Subject: *test-repo* 01/01: r4
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+From: From <from@example.com>
+Reply-To: Joe User <user@example.com>
+In-Reply-To: <...>
+References: <...>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: test-repo
+X-Git-Refname: refs/heads/release
+X-Git-Reftype: branch
+X-Git-Rev: cd654633ad4dfb51961a420fca63dca6e4e3d7ac
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a commit to branch release
+in repository test-repo.
+
+commit cd654633ad4dfb51961a420fca63dca6e4e3d7ac
+Author: Joe User <user@example.com>
+Date:   Fri Feb 3 09:34:40 2012 +0100
+
+    r4
+---
+ a.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/a.txt b/a.txt
+index b6693b6..91174ca 100644
+--- a/a.txt
++++ b/a.txt
+@@ -1 +1 @@
+-r3
++r4
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+EOF
+######################################################################
 Sending notification emails to: Refchange List <refchangelist@example.com>
 ######################################################################
 /usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF

--- a/t/multimail.expect
+++ b/t/multimail.expect
@@ -1053,22 +1053,24 @@ To stop receiving notification emails like this one, please contact
 Administrator <administrator@example.com>.
 EOF
 ######################################################################
+Sending notification emails to: Commit List <commitlist@example.com>
 ######################################################################
 /usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
 Date: ...
 To: Commit List <commitlist@example.com>
-Subject: *test-repo* 01/01: r4
+Subject: *test-repo* branch release updated: r4
 MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: 8bit
+Message-ID: <...>
 From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
-In-Reply-To: <...>
-References: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/release
 X-Git-Reftype: branch
+X-Git-Oldrev: 5f26bd17b128b6f251334af774ba502a6f590fca
+X-Git-Newrev: cd654633ad4dfb51961a420fca63dca6e4e3d7ac
 X-Git-Rev: cd654633ad4dfb51961a420fca63dca6e4e3d7ac
 Auto-Submitted: auto-generated
 
@@ -1076,6 +1078,10 @@ This is an automated email from the git hooks/post-receive script.
 
 pushuser pushed a commit to branch release
 in repository test-repo.
+
+The following commit(s) were added to refs/heads/release by this push:
+       new  cd65463   r4
+cd65463 is described below
 
 commit cd654633ad4dfb51961a420fca63dca6e4e3d7ac
 Author: Joe User <user@example.com>


### PR DESCRIPTION
When we first deployed git-multimail, the most common complaint was that it generated too much spam.  In particular, lots of folks always pushed a single commit at a time, which made the reference change summary email feel like noise.

One possible improvement here is to make the omission of the reference change email also depend on whether refchange_recipients is equal to revision_recipients.  However, since the revision_recipients could potentially change from revision to revision, that might get complex and/or costly to include.