### PR TITLE
Let From default to pusher for Gerrit and Stash

### DIFF
--- a/git-multimail/README
+++ b/git-multimail/README
@@ -51,14 +51,20 @@ By default, for each push received by the repository, git-multimail:
    + [git] 08/08: Git 1.7.11-rc2
 
    Each commit appears in exactly one commit email, the first time
-   that it is pushed to the repository.  If a commit is later merged
-   into another branch, then a one-line summary of the commit is
-   included in the reference change email (as usual), but no
+   that it is pushed to the repository[*].  If a commit is later
+   merged into another branch, then a one-line summary of the commit
+   is included in the reference change email (as usual), but no
    additional commit email is generated.
 
    By default, reference change emails have their "Reply-To" field set
    to the person who pushed the change, and commit emails have their
    "Reply-To" field set to the author of the commit.
+
+   [*] If either of multimailhook.refFilter(In|Ex)clusionRegex are
+       set, then the commit email will be sent the first time it is
+       pushed _to an included ref_ of the repository.  If neither of
+       these are set, then by default all tags and branches are
+       included.
 
 3. Output one "announce" mail for each new annotated tag, including
    information about the tag and optionally a shortlog describing the
@@ -387,6 +393,18 @@ multimailhook.replyToRefchange
 
     - The value "none", in which case the Reply-To: field will be
       omitted.
+
+multimailhook.refFilterInclusionRegex
+multimailhook.refFilterExclusionRegex
+
+    Regular expressions that can be used to limit refs for which email
+    updates will be sent.  It is an error to specify both an inclusion
+    and an exclusion regex.  If an inclusion regex is specified, emails
+    will only be sent for refs which match this regex.  If an exclusion
+    regex is specified, emails will be sent for all refs except those
+    that match this regex (or that match a predefined regex specific
+    to the environment, such as "^refs/notes" for most environments and
+    "^refs/notes|^refs/changes" for the gerrit environment).
 
 
 Email filtering aids

--- a/git-multimail/README
+++ b/git-multimail/README
@@ -158,16 +158,24 @@ multimailhook.environment
     "gitolite" -- the username of the pusher is read from $GL_USER and
         the repository name from $GL_REPO.
 
-    If neither of these environments is suitable for your setup, then
-    you can implement a Python class that inherits from Environment
-    and instantiate it via a script that looks like the example
+    "stash" -- you should probably not explicitly specify this value;
+        instead it is automatically assumed when the stash-specific
+        flags (--stash-user and --stash-repo) are specified on the
+        command line.  When this environment is active, the username
+        and repo come from these two command line flags, which must be
+        specified.
+
+    If none of these environments is suitable for your setup, then you
+    can implement a Python class that inherits from Environment and
+    instantiate it via a script that looks like the example
     post-receive script.
 
     The environment value can be specified on the command line using
     the --environment option.  If it is not specified on the command
-    line or by multimailhook.environment, then it defaults to
-    "gitolite" if the environment contains variables $GL_USER and
-    $GL_REPO; otherwise "generic".
+    line or by multimailhook.environment, and the stash-specific
+    command flags are not present on the command line, then it
+    defaults to "gitolite" if the environment contains variables
+    $GL_USER and $GL_REPO; otherwise "generic".
 
 multimailhook.repoName
 

--- a/git-multimail/README
+++ b/git-multimail/README
@@ -165,6 +165,16 @@ multimailhook.environment
         and repo come from these two command line flags, which must be
         specified.
 
+    "gerrit" -- you should probably not explicitly specify this value;
+        instead it is automatically assumed when the gerrit-specific
+        command line flags (--oldrev, --newrev, --refname, --project)
+        for gerrit's ref-updated hook are present.  When this
+        environment is active, the username of the pusher is taken
+        from the --submitter argument if that command line option is
+        passed, otherwise 'Gerrit' is used.  The repository name is
+        taken from the --project option on the command line, which
+        must be passed.
+
     If none of these environments is suitable for your setup, then you
     can implement a Python class that inherits from Environment and
     instantiate it via a script that looks like the example
@@ -172,9 +182,9 @@ multimailhook.environment
 
     The environment value can be specified on the command line using
     the --environment option.  If it is not specified on the command
-    line or by multimailhook.environment, and the stash-specific
-    command flags are not present on the command line, then it
-    defaults to "gitolite" if the environment contains variables
+    line or by multimailhook.environment, and the stash- and gerrit-
+    specific command flags are not present on the command line, then
+    it defaults to "gitolite" if the environment contains variables
     $GL_USER and $GL_REPO; otherwise "generic".
 
 multimailhook.repoName

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -2718,9 +2718,23 @@ def check_hook_specific_args(options, args):
         # The submitter argument is almost an RFC 2822 email address; change it
         # from 'User Name (email@domain)' to 'User Name <email@domain>' so it is
         options.submitter = options.submitter.replace('(','<').replace(')','>')
-        assert options.submitter.find('<') != -1
     else:
         update_method = 'submitted'
+        # Gerrit knew who submitted this patchset, but threw that information
+        # away when it invoked this hook.  However, *IF* Gerrit created a
+        # merge to bring the patchset in (project 'Submit Type' is either
+        # "Always Merge", or is "Merge if Necessary" and happens to be
+        # necessary for this particular CR), then it will have the committer
+        # of that merge be 'Gerrit Code Review' and the author will be the
+        # person who requested the submission of the CR.  Since this is fairly
+        # likely for most gerrit installations (of a reasonable size), it's
+        # worth the extra effort to try to determine the actual submitter.
+        rev_info = read_git_lines(['log', '--no-walk', '--merges',
+                                   '--format=%cN%n%aN <%aE>', options.newrev])
+        if rev_info and rev_info[0] == 'Gerrit Code Review':
+            options.submitter = rev_info[1]
+    if options.submitter:
+        assert options.submitter.find('<') != -1
 
     # We pass back refname, oldrev, newrev as args because then the
     # gerrit ref-updated hook is much like the git update hook

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -2253,6 +2253,18 @@ class GerritEnvironmentMixin(Environment):
         default = super(GerritEnvironmentMixin, self).get_default_ref_ignore_list()
         return default + '|^refs/changes/|^refs/cache-automerge/'
 
+    def get_revision_recipients(self, revision):
+        # Merge commits created by Gerrit when users hit "Submit this patchset"
+        # in the Web UI (or do equivalently with REST APIs or the gerrit review
+        # command) are not something users want to see an individual email for.
+        # Filter them out.
+        committer = read_git_output(['log', '--no-walk', '--format=%cN',
+                                     revision.rev.sha1])
+        if committer == 'Gerrit Code Review':
+            return []
+        else:
+            return super(GerritEnvironmentMixin, self).get_revision_recipients(revision)
+
 
 class GerritEnvironment(
     GerritEnvironmentMixin,

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -2208,7 +2208,11 @@ class StashEnvironmentMixin(Environment):
     def get_pusher_email(self):
         return self.__user
 
+    def get_fromaddr(self):
+        return self.__user
+
 class StashEnvironment(
+    StashEnvironmentMixin,
     ProjectdescEnvironmentMixin,
     ConfigMaxlinesEnvironmentMixin,
     ComputeFQDNEnvironmentMixin,
@@ -2217,7 +2221,6 @@ class StashEnvironment(
     ConfigBranchFilterEnvironmentMixin,
     PusherDomainEnvironmentMixin,
     ConfigOptionsEnvironmentMixin,
-    StashEnvironmentMixin,
     Environment,
     ):
     pass
@@ -2251,6 +2254,12 @@ class GerritEnvironmentMixin(Environment):
             return self.__submitter
         else:
             return super(GerritEnvironmentMixin, self).get_pusher_email()
+
+    def get_fromaddr(self):
+        if self.__submitter:
+            return self.__submitter
+        else:
+            return super(GerritEnvironmentMixin, self).get_fromaddr()
 
     def get_default_ref_ignore_regex(self):
         default = super(GerritEnvironmentMixin, self).get_default_ref_ignore_list()
@@ -2633,7 +2642,7 @@ def choose_environment(config, osenv=None, env=None, recipients=None,
             env = 'generic'
 
     if env == 'stash':
-        environment_mixins.append(KNOWN_ENVIRONMENTS[env])
+        environment_mixins.insert(0, KNOWN_ENVIRONMENTS[env])
         environment_kw['user'] = hook_info['stash_user']
         environment_kw['repo'] = hook_info['stash_repo']
     elif env == 'gerrit':

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -1543,12 +1543,17 @@ class Environment(object):
             get_reply_to_commit() is used for individual commit
             emails.
 
-        get_ref_ignore_list()
+        get_ref_filter_regex()
 
-            Return a list of refnames (or refname prefixes) that
-            should be ignored for both what emails to send and when
-            computing what commits are considered new to the
-            repository.  Default is "refs/notes/".
+            Return a tuple -- a compiled regex, and a boolean indicating
+            whether the regex picks refs to include (if False, the regex
+            matches on refs to exclude).
+
+        get_default_ref_ignore_regex()
+
+            Return a regex that should be ignored for both what emails
+            to send and when computing what commits are considered new
+            to the repository.  Default is "^refs/notes/".
 
     They should also define the following attributes:
 
@@ -1695,8 +1700,14 @@ class Environment(object):
     def get_reply_to_commit(self, revision):
         return revision.author
 
-    def get_ref_ignore_list(self):
-        return ["refs/notes/"]
+    def get_default_ref_ignore_regex(self):
+        # The commit messages of git notes are essentially meaningless
+        # and "filenames" in git notes commits are an implementational
+        # detail that might surprise users at first.  As such, we
+        # would need a completely different method for handling emails
+        # of git notes in order for them to be of benefit for users,
+        # which we simply do not have right now.
+        return "^refs/notes/"
 
     def filter_body(self, lines):
         """Filter the lines intended for an email body.
@@ -2051,6 +2062,47 @@ class ConfigRecipientsEnvironmentMixin(
             return ''
 
 
+class StaticBranchFilterEnvironmentMixin(Environment):
+    """Set branch filter statically based on constructor parameters."""
+
+    def __init__(self, ref_filter_incl_regex, ref_filter_excl_regex, **kw):
+        super(StaticBranchFilterEnvironmentMixin, self).__init__(**kw)
+
+        if ref_filter_incl_regex and ref_filter_excl_regex:
+            raise SystemExit("Cannot specify both a ref inclusion and exclusion regex.")
+        self.__is_inclusion_filter = bool(ref_filter_incl_regex)
+        default_exclude = super(StaticBranchFilterEnvironmentMixin, self).get_default_ref_ignore_regex()
+        if ref_filter_incl_regex:
+          ref_filter_regex = ref_filter_incl_regex
+        elif ref_filter_excl_regex:
+          ref_filter_regex = ref_filter_excl_regex+'|'+default_exclude
+        else:
+          ref_filter_regex = default_exclude
+
+        try:
+            self.__compiled_regex = re.compile(ref_filter_regex)
+        except Exception as e:
+            raise SystemExit('Invalid Ref Filter Regex "%s": %s' % (ref_filter_regex, e.message))
+
+    def get_ref_filter_regex(self):
+        return self.__compiled_regex, self.__is_inclusion_filter
+
+
+class ConfigBranchFilterEnvironmentMixin(
+    ConfigEnvironmentMixin,
+    StaticBranchFilterEnvironmentMixin
+    ):
+    """Determine branch filtering statically based on config."""
+
+    def __init__(self, config, **kw):
+        super(ConfigBranchFilterEnvironmentMixin, self).__init__(
+            config=config,
+            ref_filter_incl_regex=config.get('refFilterInclusionRegex'),
+            ref_filter_excl_regex=config.get('refFilterExclusionRegex'),
+            **kw
+            )
+
+
 class ProjectdescEnvironmentMixin(Environment):
     """Make a "projectdesc" value available for templates.
 
@@ -2086,6 +2138,7 @@ class GenericEnvironment(
         ComputeFQDNEnvironmentMixin,
         ConfigFilterLinesEnvironmentMixin,
         ConfigRecipientsEnvironmentMixin,
+        ConfigBranchFilterEnvironmentMixin,
         PusherDomainEnvironmentMixin,
         ConfigOptionsEnvironmentMixin,
         GenericEnvironmentMixin,
@@ -2131,6 +2184,7 @@ class GitoliteEnvironment(
         ComputeFQDNEnvironmentMixin,
         ConfigFilterLinesEnvironmentMixin,
         ConfigRecipientsEnvironmentMixin,
+        ConfigBranchFilterEnvironmentMixin,
         PusherDomainEnvironmentMixin,
         ConfigOptionsEnvironmentMixin,
         GitoliteEnvironmentMixin,
@@ -2221,12 +2275,13 @@ class Push(object):
             ])
         )
 
-    def __init__(self, changes, ref_ignore_list):
+    def __init__(self, changes, ref_filter_regex, is_inclusion_filter):
         self.changes = sorted(changes, key=self._sort_key)
 
         # The SHA-1s of commits referred to by references unaffected
         # by this push:
-        other_ref_sha1s = self._compute_other_ref_sha1s(ref_ignore_list)
+        other_ref_sha1s = self._compute_other_ref_sha1s(ref_filter_regex,
+                                                        is_inclusion_filter)
 
         self._old_rev_exclusion_spec = self._compute_rev_exclusion_spec(
             other_ref_sha1s.union(
@@ -2247,7 +2302,7 @@ class Push(object):
     def _sort_key(klass, change):
         return (klass.SORT_ORDER[change.__class__, change.change_type], change.refname,)
 
-    def _compute_other_ref_sha1s(self, ref_ignore_list):
+    def _compute_other_ref_sha1s(self, ref_filter_regex, is_inclusion_filter):
         """Return the GitObjects referred to by references unaffected by this push."""
 
         # The refnames being changed by this push:
@@ -2266,7 +2321,7 @@ class Push(object):
         for line in read_git_lines(['for-each-ref', '--format=%s' % (fmt,)]):
             (sha1, type, name) = line.split(' ', 2)
             if sha1 and type == 'commit' and name not in updated_refs and \
-               not any(name.startswith(x) for x in ref_ignore_list):
+               include_ref(name, ref_filter_regex, is_inclusion_filter):
                 sha1s.add(sha1)
 
         return sha1s
@@ -2384,24 +2439,33 @@ class Push(object):
                 )
 
 
+def include_ref(refname, ref_filter_regex, is_inclusion_filter):
+  return not (bool(ref_filter_regex.search(refname)) ^ is_inclusion_filter)
+  ## More readable version:
+  #does_match = bool(re.search(ref_filter_regex))
+  #if is_inclusion_filter:
+  #  return does_match
+  #else:  # exclusion filter -- we include the ref if the regex doesn't match
+  #  return not does_match
+
 def run_as_post_receive_hook(environment, mailer):
-    ref_ignore_list = environment.get_ref_ignore_list()
+    ref_filter_regex, is_inclusion_filter = environment.get_ref_filter_regex()
     changes = []
     for line in sys.stdin:
         (oldrev, newrev, refname) = line.strip().split(' ', 2)
-        if any(refname.startswith(x) for x in ref_ignore_list):
+        if not include_ref(refname, ref_filter_regex, is_inclusion_filter):
             continue
         changes.append(
             ReferenceChange.create(environment, oldrev, newrev, refname)
             )
     if changes:
-        push = Push(changes, ref_ignore_list)
+        push = Push(changes, ref_filter_regex, is_inclusion_filter)
         push.send_emails(mailer, body_filter=environment.filter_body)
 
 
 def run_as_update_hook(environment, mailer, refname, oldrev, newrev):
-    ref_ignore_list = environment.get_ref_ignore_list()
-    if any(refname.startswith(x) for x in ref_ignore_list):
+    ref_filter_regex, is_inclusion_filter = environment.get_ref_filter_regex()
+    if not include_ref(refname, ref_filter_regex, is_inclusion_filter):
         return
     changes = [
         ReferenceChange.create(
@@ -2411,7 +2475,7 @@ def run_as_update_hook(environment, mailer, refname, oldrev, newrev):
             refname,
             ),
         ]
-    push = Push(changes, ref_ignore_list)
+    push = Push(changes, ref_filter_regex, is_inclusion_filter)
     push.send_emails(mailer, body_filter=environment.filter_body)
 
 
@@ -2444,7 +2508,8 @@ KNOWN_ENVIRONMENTS = {
     }
 
 
-def choose_environment(config, osenv=None, env=None, recipients=None):
+def choose_environment(config, osenv=None, env=None, recipients=None,
+                       ref_filter_incl_regex=None, ref_filter_excl_regex=None):
     if not osenv:
         osenv = os.environ
 
@@ -2480,6 +2545,13 @@ def choose_environment(config, osenv=None, env=None, recipients=None):
     else:
         environment_mixins.insert(0, ConfigRecipientsEnvironmentMixin)
 
+    if ref_filter_incl_regex or ref_filter_excl_regex:
+        environment_mixins.insert(0, StaticBranchFilterEnvironmentMixin)
+        environment_kw['ref_filter_incl_regex'] = ref_filter_incl_regex
+        environment_kw['ref_filter_excl_regex'] = ref_filter_excl_regex
+    else:
+        environment_mixins.insert(0, ConfigBranchFilterEnvironmentMixin)
+
     environment_klass = type(
         'EffectiveEnvironment',
         tuple(environment_mixins) + (Environment,),
@@ -2511,6 +2583,14 @@ def main(args):
         help='Set list of email recipients for all types of emails.',
         )
     parser.add_option(
+        '--ref-filter-inclusion-regex', action='store', default=None,
+        help='Only send emails for refs matching this regex.',
+        )
+    parser.add_option(
+        '--ref-filter-exclusion-regex', action='store', default=None,
+        help='Do not send emails for refs matching this regex.',
+        )
+    parser.add_option(
         '--show-env', action='store_true', default=False,
         help=(
             'Write to stderr the values determined for the environment '
@@ -2527,6 +2607,8 @@ def main(args):
             config, osenv=os.environ,
             env=options.environment,
             recipients=options.recipients,
+            ref_filter_incl_regex=options.ref_filter_inclusion_regex,
+            ref_filter_excl_regex=options.ref_filter_exclusion_regex,
             )
 
         if options.show_env:

--- a/t/generate-test-emails
+++ b/t/generate-test-emails
@@ -119,6 +119,7 @@ test_delete refs/foo/bar
 test_hook refs/heads/master refs/heads/master^^
 
 test_update refs/heads/master refs/heads/master^^ --ref-filter-exclusion-regex ^refs/heads/master$
+test_update refs/heads/master refs/heads/master^^ --ref-filter-inclusion-regex ^refs/heads/master$
 
 rm -rf "$TESTREPO"
 

--- a/t/generate-test-emails
+++ b/t/generate-test-emails
@@ -19,27 +19,31 @@ test_email() {
     REFNAME="$1"
     OLDREV="$2"
     NEWREV="$3"
-    echo "$OLDREV" "$NEWREV" "$REFNAME" | USER=pushuser "$MULTIMAIL"
+    shift; shift; shift;
+    echo "$OLDREV" "$NEWREV" "$REFNAME" | USER=pushuser "$MULTIMAIL" "$@"
 }
 
 test_create() {
     REFNAME="$1"
     NEWREV=$(git rev-parse "$REFNAME")
-    test_email "$REFNAME" "$ZEROS" "$NEWREV"
+    shift
+    test_email "$REFNAME" "$ZEROS" "$NEWREV" "$@"
 }
 
 test_update() {
     REFNAME="$1"
     OLDREV=$(git rev-parse "$2")
     NEWREV=$(git rev-parse "$REFNAME")
-    test_email "$REFNAME" "$OLDREV" "$NEWREV"
+    shift; shift;
+    test_email "$REFNAME" "$OLDREV" "$NEWREV" "$@"
 }
 
 test_delete() {
     REFNAME="$1"
     OLDREV=$(git rev-parse "$REFNAME")
+    shift;
     git update-ref -d "$REFNAME" "$OLDREV" &&
-    test_email "$REFNAME" "$OLDREV" "$ZEROS"
+    test_email "$REFNAME" "$OLDREV" "$ZEROS" "$@"
     RETCODE=$?
     git update-ref "$REFNAME" "$OLDREV" ||
         echo 1>&2 "Error replacing reference $REFNAME to $OLDREV"
@@ -50,8 +54,9 @@ test_rewind() {
     REFNAME="$1"
     OLDREV=$(git rev-parse "$REFNAME")
     NEWREV=$(git rev-parse "$2")
+    shift; shift;
     git update-ref "$REFNAME" "$NEWREV" "$OLDREV" &&
-    test_email "$REFNAME" "$OLDREV" "$NEWREV"
+    test_email "$REFNAME" "$OLDREV" "$NEWREV" "$@"
     RETCODE=$?
     git update-ref "$REFNAME" "$OLDREV" ||
         echo 1>&2 "Error replacing reference $REFNAME to $OLDREV"
@@ -63,7 +68,8 @@ test_hook() {
     REFNAME="$1"
     OLDREV=$(git rev-parse "$2")
     NEWREV=$(git rev-parse "$REFNAME")
-    echo "$OLDREV" "$NEWREV" "$REFNAME" | USER=pushuser "$POST_RECEIVE"
+    shift; shift;
+    echo "$OLDREV" "$NEWREV" "$REFNAME" | USER=pushuser "$POST_RECEIVE" "$@"
 }
 
 test_create refs/heads/master

--- a/t/generate-test-emails
+++ b/t/generate-test-emails
@@ -118,5 +118,7 @@ test_delete refs/foo/bar
 
 test_hook refs/heads/master refs/heads/master^^
 
+test_update refs/heads/master refs/heads/master^^ --ref-filter-exclusion-regex ^refs/heads/master$
+
 rm -rf "$TESTREPO"
 

--- a/t/multimail.expect
+++ b/t/multimail.expect
@@ -3156,3 +3156,282 @@ To stop receiving notification emails like this one, please contact
 Administrator <administrator@example.com>.
 EOF
 ######################################################################
+Sending notification emails to: Refchange List <refchangelist@example.com>
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: Refchange List <refchangelist@example.com>
+Subject: *test-repo* branch master updated (ebf40e1 -> 902dfe1)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+Message-ID: <...>
+From: From <from@example.com>
+Reply-To: pushuser@example.com
+X-Git-Host: fqdn.example.org
+X-Git-Repo: test-repo
+X-Git-Refname: refs/heads/master
+X-Git-Reftype: branch
+X-Git-Oldrev: ebf40e1fe61e9b74334f80b1e8af506a36ddb57f
+X-Git-Newrev: 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a change to branch master
+in repository test-repo.
+
+      from  ebf40e1   a4
+       new  f0e9a98   f1
+       new  c742b15   f2
+       new  abb8baa   f3
+       new  d245c99   m1
+       new  902dfe1   a5
+
+The 5 revisions listed above as "new" are entirely new to this
+repository and will be described in separate emails.  The revisions
+listed as "adds" were already present in the repository and have only
+been added to this reference.
+
+
+Summary of changes:
+ a.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+EOF
+######################################################################
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: Commit List <commitlist@example.com>
+Subject: *test-repo* 01/05: f1
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+From: From <from@example.com>
+Reply-To: Joe User <user@example.com>
+In-Reply-To: <...>
+References: <...>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: test-repo
+X-Git-Refname: refs/heads/master
+X-Git-Reftype: branch
+X-Git-Rev: f0e9a982738fb14c0c66097353bf2404135624fb
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a commit to branch master
+in repository test-repo.
+
+commit f0e9a982738fb14c0c66097353bf2404135624fb
+Author: Joe User <user@example.com>
+Date:   Fri Feb 3 09:29:08 2012 +0100
+
+    f1
+---
+ a.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/a.txt b/a.txt
+index d00491f..8e1e71d 100644
+--- a/a.txt
++++ b/a.txt
+@@ -1 +1 @@
+-1
++f1
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+EOF
+######################################################################
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: Commit List <commitlist@example.com>
+Subject: *test-repo* 02/05: f2
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+From: From <from@example.com>
+Reply-To: Joe User <user@example.com>
+In-Reply-To: <...>
+References: <...>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: test-repo
+X-Git-Refname: refs/heads/master
+X-Git-Reftype: branch
+X-Git-Rev: c742b15e5c9cbb174294c1b3efaa959413bf4137
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a commit to branch master
+in repository test-repo.
+
+commit c742b15e5c9cbb174294c1b3efaa959413bf4137
+Author: Joe User <user@example.com>
+Date:   Fri Feb 3 09:29:13 2012 +0100
+
+    f2
+---
+ a.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/a.txt b/a.txt
+index 8e1e71d..9de77c1 100644
+--- a/a.txt
++++ b/a.txt
+@@ -1 +1 @@
+-f1
++f2
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+EOF
+######################################################################
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: Commit List <commitlist@example.com>
+Subject: *test-repo* 03/05: f3
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+From: From <from@example.com>
+Reply-To: Joe User <user@example.com>
+In-Reply-To: <...>
+References: <...>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: test-repo
+X-Git-Refname: refs/heads/master
+X-Git-Reftype: branch
+X-Git-Rev: abb8baa7170a6d55bc4311cc819579a929eb0b04
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a commit to branch master
+in repository test-repo.
+
+commit abb8baa7170a6d55bc4311cc819579a929eb0b04
+Author: Joe User <user@example.com>
+Date:   Fri Feb 3 09:31:22 2012 +0100
+
+    f3
+---
+ a.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/a.txt b/a.txt
+index 9de77c1..45d9e0e 100644
+--- a/a.txt
++++ b/a.txt
+@@ -1 +1 @@
+-f2
++f3
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+EOF
+######################################################################
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: Commit List <commitlist@example.com>
+Subject: *test-repo* 04/05: m1
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+From: From <from@example.com>
+Reply-To: Joe User <user@example.com>
+In-Reply-To: <...>
+References: <...>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: test-repo
+X-Git-Refname: refs/heads/master
+X-Git-Reftype: branch
+X-Git-Rev: d245c99162aff6fff4879e5d5c17d454766b45db
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a commit to branch master
+in repository test-repo.
+
+commit d245c99162aff6fff4879e5d5c17d454766b45db
+Merge: ebf40e1 abb8baa
+Author: Joe User <user@example.com>
+Date:   Fri Feb 3 09:32:27 2012 +0100
+
+    m1
+
+ a.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --cc a.txt
+index b8626c4,45d9e0e..63a911f
+--- a/a.txt
++++ b/a.txt
+@@@ -1,1 -1,1 +1,1 @@@
+- 4
+ -f3
+++m1
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+EOF
+######################################################################
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: Commit List <commitlist@example.com>
+Subject: *test-repo* 05/05: a5
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+From: From <from@example.com>
+Reply-To: Joe User <user@example.com>
+In-Reply-To: <...>
+References: <...>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: test-repo
+X-Git-Refname: refs/heads/master
+X-Git-Reftype: branch
+X-Git-Rev: 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a commit to branch master
+in repository test-repo.
+
+commit 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
+Author: Joe User <user@example.com>
+Date:   Fri Feb 3 09:32:50 2012 +0100
+
+    a5
+---
+ a.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/a.txt b/a.txt
+index 63a911f..7ed6ff8 100644
+--- a/a.txt
++++ b/a.txt
+@@ -1 +1 @@
+-m1
++5
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+EOF
+######################################################################


### PR DESCRIPTION
This pull request includes 5 commits from pull request #52 (email for only a subset of refs), 1 from pull request #53 (StashEnvironment), and 4 from pull request #54 (GerritEnvironment), because it builds on the Stash and Gerrit environments.  The only new relevant commit is the one at the end.

The default choice for 'From' seems suboptimal to me.  Setting it to be the person who made the push makes a lot more sense.

Possibly relevant tidbit: Within Palantir in our local customization hook that imports git_multimail.py, we actually do a replace('From: %(fromaddr)s', 'From: %(reply_to)s') on git_multimail.REVISION_HEADER_TEMPLATE as a backward compatibility hack.  (Our previous email solution that was commit based always set From=author, and although people agreed with me about the choice of From=pusher if we were starting from scratch, there was a strong desire to not force people to update their email filters in Outlook when we switched to git-multimail.)  As such, this commit was only effective within Palantir for a short time frame.  However, it is what I'd use anywhere else.