### PR TITLE
Handle log spam

### DIFF
--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -2325,6 +2325,45 @@ class Push(object):
         unhandled_sha1s = set(self.get_new_commits())
         send_date = IncrementalDateTime()
         for change in self.changes:
+            # In the sadly-all-too-frequent usecase of people pushing only
+            # one of their commits at a time to a repository, users feel
+            # the reference change summary emails are noise rather than
+            # important signal.  This is because, in this particular
+            # usecase, there is a reference change summary email for each
+            # new commit, and all these summaries do is point out that
+            # there is one new commit (which can readily be inferred by the
+            # existence of the individual revision email that is also
+            # sent).  In such cases, our users prefer there to be no push
+            # summary email.
+            #
+            # So, if the change is an update and it doesn't discard any
+            # commits, and it adds exactly one non-merge commit (gerrit forces
+            # a workflow where every commit is individually merged and the
+            # git-multimail hook fired off for just this one change), then we
+            # turn the push summary email off.
+            send_reference_summary_emails = True
+            try:
+                # If this change is a reference update that doesn't discard
+                # any commits...
+                if change.change_type == 'update' \
+                and [change.old.sha1] == read_git_lines(['merge-base',
+                       change.old.sha1, change.new.sha1]):
+                    # Get the new commits introduced by the push
+                    new_commits = read_git_lines(['log', '-3', '--format=%h %p',
+                       '%s..%s' % (change.old.sha1, change.new.sha1)])
+                    # If the newest commit is a merge, ignore it
+                    parents = new_commits[0].split()[1:]
+                    if len(parents) > 1:
+                        new_commits = new_commits[1:]
+                    # If there's exactly one non-merge commit introduced by
+                    # this update, turn off the reference summary email
+                    if len(new_commits) == 1 and len(new_commits[0].split())==2:
+                        send_reference_summary_emails = False
+            except CommandError:
+                # Cannot determine number of commits in old..new or new..old;
+                # don't turn off reference summary emails
+                pass
+
             # Check if we've got anyone to send to
             if not change.recipients:
                 sys.stderr.write(
@@ -2332,7 +2371,8 @@ class Push(object):
                     '*** for %r update %s->%s\n'
                     % (change.refname, change.old.sha1, change.new.sha1,)
                     )
-            else:
+                send_reference_summary_emails = False
+            if send_reference_summary_emails:
                 sys.stderr.write('Sending notification emails to: %s\n' % (change.recipients,))
                 extra_values = {'send_date': send_date.next()}
                 mailer.send(

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -830,11 +830,11 @@ class ReferenceChange(Change):
                 klass = OtherReferenceChange
             else:
                 # Some other reference namespace:
-                sys.stderr.write(
-                    '*** Push-update of strange reference %r\n'
-                    '***  - incomplete email generated.\n'
-                    % (refname,)
-                    )
+                #sys.stderr.write(
+                #    '*** Push-update of strange reference %r\n'
+                #    '***  - incomplete email generated.\n'
+                #    % (refname,)
+                #    )
                 klass = OtherReferenceChange
         else:
             # Anything else (is there anything else?)
@@ -2373,7 +2373,7 @@ class Push(object):
                     )
                 send_reference_summary_emails = False
             if send_reference_summary_emails:
-                sys.stderr.write('Sending notification emails to: %s\n' % (change.recipients,))
+                #sys.stderr.write('Sending notification emails to: %s\n' % (change.recipients,))
                 extra_values = {'send_date': send_date.next()}
                 mailer.send(
                     change.generate_email(self, body_filter, extra_values),

--- a/notes.txt
+++ b/notes.txt
@@ -75,11 +75,6 @@ Ideas for the future
   the same commit (e.g., describe them all in a single email rather
   than one email per tag).
 
-* If a single commit is pushed, emit it as a single email (not
-  refchanged + commit).
-
-  Suggested by: Ævar Arnfjörð Bjarmason <avarab@gmail.com>
-
 * Allow people to subscribe to changes only to particular files.
 
   Suggested by: Ævar Arnfjörð Bjarmason <avarab@gmail.com>

--- a/t/generate-test-emails
+++ b/t/generate-test-emails
@@ -75,6 +75,7 @@ test_rewind refs/heads/master refs/heads/feature
 test_rewind refs/heads/master refs/heads/master^
 
 test_update refs/heads/release refs/heads/release^^^^
+test_update refs/heads/release refs/heads/release^
 test_rewind refs/heads/release refs/heads/release^^
 
 test_create refs/heads/feature

--- a/t/multimail.expect
+++ b/t/multimail.expect
@@ -1053,6 +1053,52 @@ To stop receiving notification emails like this one, please contact
 Administrator <administrator@example.com>.
 EOF
 ######################################################################
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: Commit List <commitlist@example.com>
+Subject: *test-repo* 01/01: r4
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+From: From <from@example.com>
+Reply-To: Joe User <user@example.com>
+In-Reply-To: <...>
+References: <...>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: test-repo
+X-Git-Refname: refs/heads/release
+X-Git-Reftype: branch
+X-Git-Rev: cd654633ad4dfb51961a420fca63dca6e4e3d7ac
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a commit to branch release
+in repository test-repo.
+
+commit cd654633ad4dfb51961a420fca63dca6e4e3d7ac
+Author: Joe User <user@example.com>
+Date:   Fri Feb 3 09:34:40 2012 +0100
+
+    r4
+---
+ a.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/a.txt b/a.txt
+index b6693b6..91174ca 100644
+--- a/a.txt
++++ b/a.txt
+@@ -1 +1 @@
+-r3
++r4
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+EOF
+######################################################################
 Sending notification emails to: Refchange List <refchangelist@example.com>
 ######################################################################
 /usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF


### PR DESCRIPTION
This pull request includes 2 commits from pull request #51 (Emit single pushed commit as just a single email) just to avoid trivial merge conflict.  The only relevant commit for this pull request is the one RFC commit at the end.

Note: THIS PULL REQUEST SHOULDN'T BE MERGED; it breaks the tests and it breaks the current workflow for gitolite and normal git installations.

I'm submitting it this way just as a way to ask for ideas for a better way to handle this.  Basically, for normal git or gitolite, these messages would be sent to the user when they do a push.  For gerrit and stash, they won't.  In gerrit's case, they spam the system error log, which is really annoying as these messages are merely informational in nature and are not actual errors.