### PR TITLE
Add a __contains__ method to Config to address pep8 issues

### DIFF
--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -452,6 +452,9 @@ class Config(object):
     def has_key(self, name):
         return self.get_all(name, default=None) is not None
 
+    def __contains__(self, x):
+        return self.has_key(x)
+
     def unset_all(self, name):
         try:
             read_git_output(


### PR DESCRIPTION
In 09d0d5b (Get Python files to pass pep8's tests. 2014-05-09), there were
a few changes from 'old.has_key(name)' to 'name in old'.  However, our
Config class only supported the has_key() API, resulting in an ugly
traceback when users went to run migrate-mailhook-config.  Add a
**contains** method to allow the new call style to work.

Reported-by: Azat Khuzhin a3at.mail@gmail.com
Signed-off-by: Elijah Newren newren@palantir.com
