### PR TITLE
Don't throw en exception when there is no emails.

### DIFF
--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -1990,7 +1990,8 @@ class StaticRecipientsEnvironmentMixin(Environment):
         if not (refchange_recipients
                 or announce_recipients
                 or revision_recipients):
-            raise ConfigurationException('No email recipients configured!')
+            sys.stderr.write('No email recipients configured!\n')
+            sys.exit(0)
         self.__refchange_recipients = refchange_recipients
         self.__announce_recipients = announce_recipients
         self.__revision_recipients = revision_recipients


### PR DESCRIPTION
This allow to just enable this script for all projects, and enable
patch-sending feature only for specific project.
This patch still write message to stderr

Signed-off-by: Azat Khuzhin <a3at.mail@gmail.com>