### PR TITLE
Support new option .scancommitforcc

### DIFF
--- a/git-multimail/README
+++ b/git-multimail/README
@@ -389,6 +389,12 @@ multimailhook.replyToRefchange
     - The value "none", in which case the Reply-To: field will be
       omitted.
 
+multimailhook.scancommitforcc
+
+    If this option is set to true, than recipients from lines in commit body
+    that starts with "CC:" will be added to CC list.
+    Default: false
+
 
 Email filtering aids
 --------------------

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -732,7 +732,7 @@ class Revision(Change):
         if self.environment.get_scancommitforcc():
             self.cc_recipients = ', '.join(to.strip() for to in self._cc_recipients())
             if self.cc_recipients:
-                sys.stderr.write('Add %s to CC\n' % self.cc_recipients)
+                sys.stderr.write('Add %s to CC for %s\n' % (self.cc_recipients, self.rev.sha1))
 
     def _cc_recipients(self):
         cc_recipients = []

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -717,7 +717,7 @@ class Change(object):
 class Revision(Change):
     """A Change consisting of a single git commit."""
 
-    CC_RE = re.compile(r'^\s*(?:C(?:c|C):\s*)(?P<to>.+)\s*$')
+    CC_RE = re.compile(r'^\s*(?:C(?:c|C):\s*)(?P<to>.+)(?:\s*#.*|\s*)$')
 
     def __init__(self, reference_change, rev, num, tot):
         Change.__init__(self, reference_change.environment)

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -230,6 +230,7 @@ how to provide full information about this reference change.
 REVISION_HEADER_TEMPLATE = """\
 Date: %(send_date)s
 To: %(recipients)s
+CC: %(cc_recipients)s
 Subject: %(emailprefix)s%(num)02d/%(tot)02d: %(oneline)s
 MIME-Version: 1.0
 Content-Type: text/plain; charset=%(charset)s
@@ -716,6 +717,8 @@ class Change(object):
 class Revision(Change):
     """A Change consisting of a single git commit."""
 
+    CC_RE = re.compile(r'^\s*(?:C(?:c|C):\s*)(?P<to>.+)\s*$')
+
     def __init__(self, reference_change, rev, num, tot):
         Change.__init__(self, reference_change.environment)
         self.reference_change = reference_change
@@ -726,6 +729,21 @@ class Revision(Change):
         self.tot = tot
         self.author = read_git_output(['log', '--no-walk', '--format=%aN <%aE>', self.rev.sha1])
         self.recipients = self.environment.get_revision_recipients(self)
+        if self.environment.get_scancommitforcc():
+            self.cc_recipients = ', '.join(to.strip() for to in self._cc_recipients())
+            if self.cc_recipients:
+                sys.stderr.write('Add %s to CC\n' % self.cc_recipients)
+
+    def _cc_recipients(self):
+        cc_recipients = []
+        message = read_git_output(['log', '--no-walk', '--format=%b', self.rev.sha1])
+        lines = message.strip().split('\n')
+        for line in lines:
+            m = re.match(self.CC_RE, line)
+            if m:
+                cc_recipients.append(m.group('to'))
+
+        return cc_recipients
 
     def _compute_values(self):
         values = Change._compute_values(self)
@@ -744,6 +762,7 @@ class Revision(Change):
         values['num'] = self.num
         values['tot'] = self.tot
         values['recipients'] = self.recipients
+        values['cc_recipients'] = self.cc_recipients
         values['oneline'] = oneline
         values['author'] = self.author
 
@@ -1830,6 +1849,9 @@ class ConfigOptionsEnvironmentMixin(ConfigEnvironmentMixin):
             return None
         else:
             return self.__reply_to_commit
+
+    def get_scancommitforcc(self):
+        return self.config.get('scancommitforcc')
 
 
 class FilterLinesEnvironmentMixin(Environment):

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -717,7 +717,7 @@ class Change(object):
 class Revision(Change):
     """A Change consisting of a single git commit."""
 
-    CC_RE = re.compile(r'^\s*(?:C(?:c|C):\s*)(?P<to>.+)(?:\s*#.*|\s*)$')
+    CC_RE = re.compile(r'^\s*(?:C(?:c|C):\s*)(?P<to>[^#]+)(?:\s*#.*|\s*)$')
 
     def __init__(self, reference_change, rev, num, tot):
         Change.__init__(self, reference_change.environment)

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -729,6 +729,8 @@ class Revision(Change):
         self.tot = tot
         self.author = read_git_output(['log', '--no-walk', '--format=%aN <%aE>', self.rev.sha1])
         self.recipients = self.environment.get_revision_recipients(self)
+
+        self.cc_recipients = ''
         if self.environment.get_scancommitforcc():
             self.cc_recipients = ', '.join(to.strip() for to in self._cc_recipients())
             if self.cc_recipients:

--- a/git-multimail/migrate-mailhook-config
+++ b/git-multimail/migrate-mailhook-config
@@ -22,6 +22,7 @@ OLD_NAMES = [
     'showrev',
     'emailmaxlines',
     'diffopts',
+    'scancommitforcc',
     ]
 
 NEW_NAMES = [
@@ -38,6 +39,7 @@ NEW_NAMES = [
     'emailmaxlines',
     'diffopts',
     'emaildomain',
+    'scancommitforcc',
     ]
 
 
@@ -198,7 +200,7 @@ def migrate_config(strict=False, retain=False, overwrite=False):
             )
         new.set('announceshortlog', 'true')
 
-    for name in ['envelopesender', 'emailmaxlines', 'diffopts']:
+    for name in ['envelopesender', 'emailmaxlines', 'diffopts', 'scancommitforcc']:
         if name in old:
             sys.stderr.write(
                 '...copying "%s.%s" to "%s.%s"\n' % (old.section, name, new.section, name)


### PR DESCRIPTION
I don't really sure is it useful for some others.
But I think that it could be, you can just write in commit:
```
Fix memory leak

Cc: tests@product
```
And it will send email to "tests@product" with only this commit.
Thanks.

(And definitely no documentation, but if this will be useful, I will do.)