### PR TITLE
Fix testsuite compatibility

### DIFF
--- a/t/filter-noise
+++ b/t/filter-noise
@@ -3,8 +3,8 @@
 # Filter out strings that vary uninterestingly from one test run to
 # the next.
 
-sed -E \
-    -e 's/^(In-Reply-To|Message-ID|References): <.*>$/\1: <...>/' \
-    -e 's/^(Date): [^ ].*$/\1: .../' \
+sed \
+    -e 's/^\(In-Reply-To\|Message-ID\|References\): <.*>$/\1: <...>/' \
+    -e 's/^\(Date\): [^ ].*$/\1: .../' \
     -e "s/^X-Git-Host: `hostname --fqdn`$/X-Git-Host: fqdn.example.org/"
 

--- a/t/test-env
+++ b/t/test-env
@@ -5,9 +5,13 @@ import sys
 import os
 import shutil
 import subprocess
-import contextlib
 import unittest
-import email.utils
+
+try:
+    from email.utils import formataddr
+except ImportError:
+    # Prior to Python 2.5, the email module used different names:
+    from email.Utils import formataddr
 
 TEST_DIR = os.path.abspath(os.path.dirname(sys.argv[0]))
 PROJ_DIR = os.path.dirname(TEST_DIR)
@@ -23,11 +27,11 @@ from git_multimail import addr_header_encode, header_encode
 
 
 class HelperTest(unittest.TestCase):
-    LONG_ASCII_ADDR = email.utils.formataddr((
+    LONG_ASCII_ADDR = formataddr((
         'Nobodywouldhavesuchaninsanelongname Butwhoknowswhathappens',
         'somelong.sampleaddr@example.com',
     ))
-    LONG_UNICODE_ADDR = email.utils.formataddr((
+    LONG_UNICODE_ADDR = formataddr((
         u'Raphaël Gilbert André Hertzog',
         'somelong.sampleaddr@example.com',
     ))
@@ -103,10 +107,12 @@ class EnvTest(unittest.TestCase):
         self.old_dir = os.getcwd()
         if os.path.isdir(REPO):
             shutil.rmtree(REPO)
-        subprocess.check_call(
+        retcode = subprocess.call(
             ['git', 'init', '--bare', REPO],
             stdout=open('/dev/null', 'w'), stderr=subprocess.STDOUT,
             )
+        self.assertEqual(retcode, 0,
+            'git init --bare "%s" returned %d' % (REPO, retcode))
         os.chdir(REPO)
         user_config = Config('user')
         if self.user_config is None:


### PR DESCRIPTION
CentOS 5 needs the following fixes to the testsuite:
* Don't use sed -E (it has GNU sed 4.1 which doesn't support that)
* Support python 2.4 in test-env.