### PR TITLE
Fix use of "replyToCommit = author"

### DIFF
--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -1823,7 +1823,7 @@ class ConfigOptionsEnvironmentMixin(ConfigEnvironmentMixin):
         if self.__reply_to_commit is None:
             return super(ConfigOptionsEnvironmentMixin, self).get_reply_to_commit(revision)
         elif self.__reply_to_commit.lower() == 'author':
-            return revision.get_author()
+            return revision.author
         elif self.__reply_to_commit.lower() == 'pusher':
             return self.get_pusher_email()
         elif self.__reply_to_commit.lower() == 'none':


### PR DESCRIPTION
When setting "replyToCommit" to "author", sending the commit mail fails because of an AttributeError "'Revision' object has no attribute 'get_author'".