### PR TITLE
Html colored email for diffs

### DIFF
--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -85,7 +85,7 @@ ADDR_HEADERS = set(['from', 'to', 'cc', 'bcc', 'reply-to', 'sender'])
 # where the encoding is important.
 (ENCODING, CHARSET) = ('UTF-8', 'utf-8')
 
-CONTENTTYPE = 'html'
+CONTENTTYPE = 'plain'
 
 
 REF_CREATED_SUBJECT_TEMPLATE = (


### PR DESCRIPTION

So here is a change to  allow you to have colored html diffs in your diff emails.  I tried to limit it entirely to a mixin class, but I had to add a little bit of code to the email level that adds some line break tags
if we're sending text/html mail, because of course the whole email message is html or not, not just the diff itself.