### PR TITLE
Bug fix for sending emails for the new environment.quiet flag.

### DIFF
--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -2358,7 +2358,7 @@ class Push(object):
                     % (change.refname, change.old.sha1, change.new.sha1,)
                     )
             else:
-                if not self.environment.quiet:
+                if not change.environment.quiet:
                     sys.stderr.write('Sending notification emails to: %s\n' % (change.recipients,))
                 extra_values = {'send_date': send_date.next()}
                 mailer.send(


### PR DESCRIPTION
I had to make this simple fix for running the git-multimail script using upstream master.  Feel free to take it if it is not already fixed.