### PR TITLE
Fall back to USERNAME if USER is not set

### DIFF
--- a/git-multimail/README
+++ b/git-multimail/README
@@ -146,8 +146,9 @@ multimailhook.environment
     This describes the general environment of the repository.
     Currently supported values:
 
-    "generic" -- the username of the pusher is read from $USER and the
-        repository name is derived from the repository's path.
+    "generic" -- the username of the pusher is read from $USER or
+        $USERNAME and the repository name is derived from the
+        repository's path.
 
     "gitolite" -- the username of the pusher is read from $GL_USER and
         the repository name from $GL_REPO.

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -2092,7 +2092,7 @@ class ProjectdescEnvironmentMixin(Environment):
 
 class GenericEnvironmentMixin(Environment):
     def get_pusher(self):
-        return self.osenv.get('USER', 'unknown user')
+        return self.osenv.get('USER', self.osenv.get('USERNAME', 'unknown user'))
 
 
 class GenericEnvironment(


### PR DESCRIPTION
Windows sets USERNAME instead of USER. This fixes issue #61.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>