### PR TITLE
Fewer emails if single commit pushed v2

### DIFF
--- a/git-multimail/CHANGES
+++ b/git-multimail/CHANGES
@@ -1,3 +1,9 @@
+Release ?.?.?
+=============
+
+* When a single commit is pushed, omit the reference changed email.
+
+
 Release 1.0.0
 =============
 

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -874,6 +874,10 @@ class ReferenceChange(Change):
         self.commitlogopts = environment.commitlogopts
         self.showlog = environment.refchange_showlog
 
+        self.header_template = REFCHANGE_HEADER_TEMPLATE
+        self.intro_template = REFCHANGE_INTRO_TEMPLATE
+        self.footer_template = FOOTER_TEMPLATE
+
     def _compute_values(self):
         values = Change._compute_values(self)
 
@@ -940,12 +944,12 @@ class ReferenceChange(Change):
             extra_values['subject'] = self.get_subject()
 
         for line in self.expand_header_lines(
-                REFCHANGE_HEADER_TEMPLATE, **extra_values
+                self.header_template, **extra_values
                 ):
             yield line
 
     def generate_email_intro(self):
-        for line in self.expand_lines(REFCHANGE_INTRO_TEMPLATE):
+        for line in self.expand_lines(self.intro_template):
             yield line
 
     def generate_email_body(self, push):
@@ -966,7 +970,7 @@ class ReferenceChange(Change):
             yield line
 
     def generate_email_footer(self):
-        return self.expand_lines(FOOTER_TEMPLATE)
+        return self.expand_lines(self.footer_template)
 
     def generate_revision_change_log(self, new_commits_list):
         if self.showlog:

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -1303,10 +1303,15 @@ class BranchChange(ReferenceChange):
                 ):
                 return None
 
+            # We do not want to combine revision and refchange emails if
+            # those go to separate locations.
+            rev = Revision(self, GitObject(new_commits[0][0]), 1, tot)
+            if rev.recipients != self.recipients:
+                return None
+
             # We can combine the refchange and one new revision emails
             # into one.  Return the Revision that a combined email should
             # be sent about.
-            rev = Revision(self, GitObject(new_commits[0][0]), 1, tot)
             return rev
         except CommandError:
             # Cannot determine number of commits in old..new or new..old;

--- a/notes.txt
+++ b/notes.txt
@@ -75,11 +75,6 @@ Ideas for the future
   the same commit (e.g., describe them all in a single email rather
   than one email per tag).
 
-* If a single commit is pushed, emit it as a single email (not
-  refchanged + commit).
-
-  Suggested by: Ævar Arnfjörð Bjarmason <avarab@gmail.com>
-
 * Allow people to subscribe to changes only to particular files.
 
   Suggested by: Ævar Arnfjörð Bjarmason <avarab@gmail.com>

--- a/t/generate-test-emails
+++ b/t/generate-test-emails
@@ -75,6 +75,7 @@ test_rewind refs/heads/master refs/heads/feature
 test_rewind refs/heads/master refs/heads/master^
 
 test_update refs/heads/release refs/heads/release^^^^
+test_update refs/heads/release refs/heads/release^
 test_rewind refs/heads/release refs/heads/release^^
 
 test_create refs/heads/feature

--- a/t/generate-test-emails
+++ b/t/generate-test-emails
@@ -75,7 +75,14 @@ test_rewind refs/heads/master refs/heads/feature
 test_rewind refs/heads/master refs/heads/master^
 
 test_update refs/heads/release refs/heads/release^^^^
+
+# Should send both summary and revision email:
 test_update refs/heads/release refs/heads/release^
+# Should send a combined email:
+git config multimailhook.refchangelist 'Commit List <commitlist@example.com>'
+test_update refs/heads/release refs/heads/release^
+git config multimailhook.refchangelist 'Refchange List <refchangelist@example.com>'
+
 test_rewind refs/heads/release refs/heads/release^^
 
 test_create refs/heads/feature

--- a/t/multimail.expect
+++ b/t/multimail.expect
@@ -1058,18 +1058,19 @@ Sending notification emails to: Refchange List <refchangelist@example.com>
 /usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
 Date: ...
 To: Commit List <commitlist@example.com>
-Subject: *test-repo* 01/01: r4
+Subject: *test-repo* branch release updated: r4
 MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: 8bit
+Message-ID: <...>
 From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
-In-Reply-To: <...>
-References: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/release
 X-Git-Reftype: branch
+X-Git-Oldrev: 5f26bd17b128b6f251334af774ba502a6f590fca
+X-Git-Newrev: cd654633ad4dfb51961a420fca63dca6e4e3d7ac
 X-Git-Rev: cd654633ad4dfb51961a420fca63dca6e4e3d7ac
 Auto-Submitted: auto-generated
 
@@ -1077,6 +1078,10 @@ This is an automated email from the git hooks/post-receive script.
 
 pushuser pushed a commit to branch release
 in repository test-repo.
+
+The following commit(s) were added to refs/heads/release by this push:
+       new  cd65463   r4
+cd65463 is described below
 
 commit cd654633ad4dfb51961a420fca63dca6e4e3d7ac
 Author: Joe User <user@example.com>

--- a/t/multimail.expect
+++ b/t/multimail.expect
@@ -1105,6 +1105,58 @@ To stop receiving notification emails like this one, please contact
 Administrator <administrator@example.com>.
 EOF
 ######################################################################
+Sending notification emails to: Commit List <commitlist@example.com>
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: Commit List <commitlist@example.com>
+Subject: *test-repo* branch release updated: r4
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+Message-ID: <...>
+From: From <from@example.com>
+Reply-To: Joe User <user@example.com>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: test-repo
+X-Git-Refname: refs/heads/release
+X-Git-Reftype: branch
+X-Git-Oldrev: 5f26bd17b128b6f251334af774ba502a6f590fca
+X-Git-Newrev: cd654633ad4dfb51961a420fca63dca6e4e3d7ac
+X-Git-Rev: cd654633ad4dfb51961a420fca63dca6e4e3d7ac
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a commit to branch release
+in repository test-repo.
+
+The following commit(s) were added to refs/heads/release by this push:
+       new  cd65463   r4
+cd65463 is described below
+
+commit cd654633ad4dfb51961a420fca63dca6e4e3d7ac
+Author: Joe User <user@example.com>
+Date:   Fri Feb 3 09:34:40 2012 +0100
+
+    r4
+---
+ a.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/a.txt b/a.txt
+index b6693b6..91174ca 100644
+--- a/a.txt
++++ b/a.txt
+@@ -1 +1 @@
+-r3
++r4
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+EOF
+######################################################################
 Sending notification emails to: Refchange List <refchangelist@example.com>
 ######################################################################
 /usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF

--- a/t/multimail.expect
+++ b/t/multimail.expect
@@ -1057,6 +1057,53 @@ Sending notification emails to: Refchange List <refchangelist@example.com>
 ######################################################################
 /usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
 Date: ...
+To: Commit List <commitlist@example.com>
+Subject: *test-repo* 01/01: r4
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+From: From <from@example.com>
+Reply-To: Joe User <user@example.com>
+In-Reply-To: <...>
+References: <...>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: test-repo
+X-Git-Refname: refs/heads/release
+X-Git-Reftype: branch
+X-Git-Rev: cd654633ad4dfb51961a420fca63dca6e4e3d7ac
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a commit to branch release
+in repository test-repo.
+
+commit cd654633ad4dfb51961a420fca63dca6e4e3d7ac
+Author: Joe User <user@example.com>
+Date:   Fri Feb 3 09:34:40 2012 +0100
+
+    r4
+---
+ a.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/a.txt b/a.txt
+index b6693b6..91174ca 100644
+--- a/a.txt
++++ b/a.txt
+@@ -1 +1 @@
+-r3
++r4
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+EOF
+######################################################################
+Sending notification emails to: Refchange List <refchangelist@example.com>
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
 To: Refchange List <refchangelist@example.com>
 Subject: *test-repo* branch release updated (cd65463 -> 1034ac6)
 MIME-Version: 1.0

--- a/t/multimail.expect
+++ b/t/multimail.expect
@@ -1057,20 +1057,61 @@ Sending notification emails to: Refchange List <refchangelist@example.com>
 ######################################################################
 /usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
 Date: ...
-To: Commit List <commitlist@example.com>
-Subject: *test-repo* branch release updated: r4
+To: Refchange List <refchangelist@example.com>
+Subject: *test-repo* branch release updated (5f26bd1 -> cd65463)
 MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
-Reply-To: Joe User <user@example.com>
+Reply-To: pushuser@example.com
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/release
 X-Git-Reftype: branch
 X-Git-Oldrev: 5f26bd17b128b6f251334af774ba502a6f590fca
 X-Git-Newrev: cd654633ad4dfb51961a420fca63dca6e4e3d7ac
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a change to branch release
+in repository test-repo.
+
+      from  5f26bd1   r3
+       new  cd65463   r4
+
+The 1 revisions listed above as "new" are entirely new to this
+repository and will be described in separate emails.  The revisions
+listed as "adds" were already present in the repository and have only
+been added to this reference.
+
+
+Summary of changes:
+ a.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+EOF
+######################################################################
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: Commit List <commitlist@example.com>
+Subject: *test-repo* 01/01: r4
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+From: From <from@example.com>
+Reply-To: Joe User <user@example.com>
+In-Reply-To: <...>
+References: <...>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: test-repo
+X-Git-Refname: refs/heads/release
+X-Git-Reftype: branch
 X-Git-Rev: cd654633ad4dfb51961a420fca63dca6e4e3d7ac
 Auto-Submitted: auto-generated
 
@@ -1078,10 +1119,6 @@ This is an automated email from the git hooks/post-receive script.
 
 pushuser pushed a commit to branch release
 in repository test-repo.
-
-The following commit(s) were added to refs/heads/release by this push:
-       new  cd65463   r4
-cd65463 is described below
 
 commit cd654633ad4dfb51961a420fca63dca6e4e3d7ac
 Author: Joe User <user@example.com>


### PR DESCRIPTION
This is a reroll of PR #51. Essentially, I

* Rebased on master
* Squashed fixup commits
* Made the history bisectable. Each commit now passes the tests, so one can review the behavior change by reading the diff on t/multimail.expect.

I did my own review and think it is ready for merging, but I'm posting it as a PR to let @newren and @mhagger an opportunity to review one last time.