### PR TITLE
Allow to use scanCommitForCc without any global recipients

### DIFF
--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -2021,7 +2021,7 @@ class StaticRecipientsEnvironmentMixin(Environment):
 
     def __init__(
             self,
-            refchange_recipients, announce_recipients, revision_recipients,
+            refchange_recipients, announce_recipients, revision_recipients, scancommitforcc,
             **kw
             ):
         super(StaticRecipientsEnvironmentMixin, self).__init__(**kw)
@@ -2035,7 +2035,8 @@ class StaticRecipientsEnvironmentMixin(Environment):
         # compute them once and for all:
         if not (refchange_recipients
                 or announce_recipients
-                or revision_recipients):
+                or revision_recipients
+                or scancommitforcc):
             raise ConfigurationException('No email recipients configured!')
         self.__refchange_recipients = refchange_recipients
         self.__announce_recipients = announce_recipients
@@ -2069,6 +2070,8 @@ class ConfigRecipientsEnvironmentMixin(
             revision_recipients=self._get_recipients(
                 config, 'commitlist', 'mailinglist',
                 ),
+            scancommitforcc=config.get('scancommitforcc')
+                ,
             **kw
             )
 
@@ -2408,7 +2411,7 @@ class Push(object):
 
             for (num, sha1) in enumerate(sha1s):
                 rev = Revision(change, GitObject(sha1), num=num + 1, tot=len(sha1s))
-                if rev.recipients:
+                if rev.recipients or rev.cc_recipients:
                     extra_values = {'send_date': send_date.next()}
                     mailer.send(
                         rev.generate_email(self, body_filter, extra_values),

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -2411,7 +2411,11 @@ class Push(object):
 
             for (num, sha1) in enumerate(sha1s):
                 rev = Revision(change, GitObject(sha1), num=num + 1, tot=len(sha1s))
-                if rev.recipients or rev.cc_recipients:
+                if not rev.recipients and rev.cc_recipients:
+                    sys.stderr.write('*** Replace Cc: with To:\n')
+                    rev.recipients = rev.cc_recipients
+                    rev.cc_recipients = None
+                if rev.recipients:
                     extra_values = {'send_date': send_date.next()}
                     mailer.send(
                         rev.generate_email(self, body_filter, extra_values),

--- a/t/generate-test-emails
+++ b/t/generate-test-emails
@@ -115,5 +115,10 @@ test_hook refs/heads/master refs/heads/master^^
 git config multimailhook.scanCommitForCc true
 test_update refs/heads/formatting refs/heads/formatting^^^
 
+for o in mailinglist refchangelist announcelist commitlist; do
+    git config multimailhook.$o ''
+done
+test_update refs/heads/formatting refs/heads/formatting^^^
+
 rm -rf "$TESTREPO"
 

--- a/t/multimail.expect
+++ b/t/multimail.expect
@@ -3361,11 +3361,11 @@ EOF
 *** no recipients configured so no email will be sent
 *** for 'refs/heads/formatting' update 6522cd3759908339b14ab0048bc1d756929ac112->8e11f7c6a6a86d37ac1f3e9ce6ec7d1399412c17
 Add Some One <Some.One@example.com>, Another Guy <Another.Guy@example.com>, Third.Guy@example.com to CC for 919426837aa07c18459a0acc0f789b6a8cd8fb80
+*** Replace Cc: with To:
 ######################################################################
 /usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
 Date: ...
-To: 
-Cc: Some One <Some.One@example.com>, Another Guy <Another.Guy@example.com>,
+To: Some One <Some.One@example.com>, Another Guy <Another.Guy@example.com>,
  Third.Guy@example.com
 Subject: *test-repo* 01/03: Subject line
 MIME-Version: 1.0
@@ -3414,11 +3414,11 @@ Administrator <administrator@example.com>.
 EOF
 ######################################################################
 Add me@example.com to CC for 850c489cf431841cf428e00fc8285456682a9d13
+*** Replace Cc: with To:
 ######################################################################
 /usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
 Date: ...
-To: 
-Cc: me@example.com
+To: me@example.com
 Subject: *test-repo* 02/03: Another subject line
 MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8

--- a/t/multimail.expect
+++ b/t/multimail.expect
@@ -3358,3 +3358,111 @@ To stop receiving notification emails like this one, please contact
 Administrator <administrator@example.com>.
 EOF
 ######################################################################
+*** no recipients configured so no email will be sent
+*** for 'refs/heads/formatting' update 6522cd3759908339b14ab0048bc1d756929ac112->8e11f7c6a6a86d37ac1f3e9ce6ec7d1399412c17
+Add Some One <Some.One@example.com>, Another Guy <Another.Guy@example.com>, Third.Guy@example.com to CC for 919426837aa07c18459a0acc0f789b6a8cd8fb80
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: 
+Cc: Some One <Some.One@example.com>, Another Guy <Another.Guy@example.com>,
+ Third.Guy@example.com
+Subject: *test-repo* 01/03: Subject line
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+From: From <from@example.com>
+Reply-To: Matthieu Moy <Matthieu.Moy@imag.fr>
+In-Reply-To: <...>
+References: <...>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: test-repo
+X-Git-Refname: refs/heads/formatting
+X-Git-Reftype: branch
+X-Git-Rev: 919426837aa07c18459a0acc0f789b6a8cd8fb80
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a commit to branch formatting
+in repository test-repo.
+
+commit 919426837aa07c18459a0acc0f789b6a8cd8fb80
+Author: Matthieu Moy <Matthieu.Moy@imag.fr>
+Date:   Sun May 24 19:57:13 2015 +0200
+
+    Subject line
+    
+    Cc: Some One <Some.One@example.com> # this guy wants to receive emails.
+     CC: Another Guy <Another.Guy@example.com>
+    Cc:Third.Guy@example.com
+---
+ foo.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/foo.txt b/foo.txt
+index 257cc56..eec8bfc 100644
+--- a/foo.txt
++++ b/foo.txt
+@@ -1 +1,2 @@
+ foo
++new-content
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+EOF
+######################################################################
+Add me@example.com to CC for 850c489cf431841cf428e00fc8285456682a9d13
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: 
+Cc: me@example.com
+Subject: *test-repo* 02/03: Another subject line
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+From: From <from@example.com>
+Reply-To: Matthieu Moy <Matthieu.Moy@imag.fr>
+In-Reply-To: <...>
+References: <...>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: test-repo
+X-Git-Refname: refs/heads/formatting
+X-Git-Reftype: branch
+X-Git-Rev: 850c489cf431841cf428e00fc8285456682a9d13
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a commit to branch formatting
+in repository test-repo.
+
+commit 850c489cf431841cf428e00fc8285456682a9d13
+Author: Matthieu Moy <Matthieu.Moy@imag.fr>
+Date:   Sun May 24 19:58:34 2015 +0200
+
+    Another subject line
+    
+    This is the body.
+    And below is the Cc: line.
+    Cc: me@example.com
+---
+ foo.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/foo.txt b/foo.txt
+index eec8bfc..f601cee 100644
+--- a/foo.txt
++++ b/foo.txt
+@@ -1,2 +1,3 @@
+ foo
+ new-content
++new-content
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+EOF
+######################################################################


### PR DESCRIPTION
Since it is still useful to just write "Cc:" in commit message and send only
particular patch to specific email, without any mailinglist.

By global recipients I mean one of the following:
- mailinglist
- refchangelist
- announcelist
- commitlist

Also regression test added.

Signed-off-by: Azat Khuzhin <a3at.mail@gmail.com>