### PR TITLE
disable the pager when running 'git diff`

### DIFF
--- a/t/test-email-content
+++ b/t/test-email-content
@@ -7,7 +7,7 @@ cd "${d}" || exit 1
 log "Comparing generated emails to $d/multimail.expect ..."
 
 ./generate-test-emails 2>&1 | ./filter-noise >/tmp/multimail.actual
-git diff -u multimail.expect /tmp/multimail.actual
+GIT_PAGER=cat git diff -u multimail.expect /tmp/multimail.actual
 if test $? -ne 0
 then
     fatal "


### PR DESCRIPTION
If the user has a custom pager config, the pager might run while running tests.  This makes it harder to parse the test results, so disable the pager.