### PR TITLE
Email for subset of refs

### DIFF
--- a/git-multimail/CHANGES
+++ b/git-multimail/CHANGES
@@ -12,6 +12,10 @@ Release 1.2.0
   of notifications. Current values are: diff, ref_changed_plus_diff,
   ref_changed.
 
+* It is now possible to exclude some refs (e.g. exclude some branches
+  or tags). See refFilterDoSendRegex, refFilterDontSendRegex,
+  refFilterInclusionRegex and refFilterExclusionRegex.
+
 Release 1.1.0
 =============
 

--- a/git-multimail/README
+++ b/git-multimail/README
@@ -515,6 +515,11 @@ multimailhook.refFilterExclusionRegex
 multimailhook.refFilterDoSendRegex
 multimailhook.refFilterDontSendRegex
 
+    **Warning:** these options are experimental. They should work, but
+    the user-interface is not stable yet (in particular, the option
+    names may change). If you want to participate in stabilizing the
+    feature, please contact the maintainers and/or send pull-requests.
+
     Regular expressions that can be used to limit refs for which email
     updates will be sent.  It is an error to specify both an inclusion
     and an exclusion regex.  If a ``refFilterInclusionRegex`` is

--- a/git-multimail/README
+++ b/git-multimail/README
@@ -512,15 +512,31 @@ multimailhook.combineWhenSingleCommit
 
 multimailhook.refFilterInclusionRegex
 multimailhook.refFilterExclusionRegex
+multimailhook.refFilterDoSendRegex
+multimailhook.refFilterDontSendRegex
 
     Regular expressions that can be used to limit refs for which email
     updates will be sent.  It is an error to specify both an inclusion
-    and an exclusion regex.  If an inclusion regex is specified, emails
-    will only be sent for refs which match this regex.  If an exclusion
-    regex is specified, emails will be sent for all refs except those
-    that match this regex (or that match a predefined regex specific
-    to the environment, such as "^refs/notes" for most environments and
+    and an exclusion regex.  If a ``refFilterInclusionRegex`` is
+    specified, emails will only be sent for refs which match this
+    regex.  If a ``refFilterExclusionRegex`` regex is specified,
+    emails will be sent for all refs except those that match this
+    regex (or that match a predefined regex specific to the
+    environment, such as "^refs/notes" for most environments and
     "^refs/notes|^refs/changes" for the gerrit environment).
+
+    ``refFilterDoSendRegex`` and ``refFilterDontSendRegex`` are
+    analogous to ``refFilterInclusionRegex`` and
+    ``refFilterExclusionRegex`` with one difference: with
+    ``refFilterDoSendRegex`` and ``refFilterDontSendRegex``, commits
+    introduced by one excluded ref will not be considered as new when
+    they reach an included ref. Typically, if you add a branch ``foo``
+    to  ``refFilterDontSendRegex``, push commits to this branch, and
+    later merge branch ``foo`` into ``master``, then the notification
+    email for ``master`` will contain a commit email only for the
+    merge commit. If you include ``foo`` in
+    ``refFilterExclusionRegex``, then at the time of merge, you will
+    receive one commit email per commit in the branch.
 
 
 Email filtering aids

--- a/git-multimail/README
+++ b/git-multimail/README
@@ -54,14 +54,20 @@ By default, for each push received by the repository, git-multimail:
      + [git] 08/08: Git 1.7.11-rc2
 
    Each commit appears in exactly one commit email, the first time
-   that it is pushed to the repository.  If a commit is later merged
-   into another branch, then a one-line summary of the commit is
-   included in the reference change email (as usual), but no
+   that it is pushed to the repository[*].  If a commit is later
+   merged into another branch, then a one-line summary of the commit
+   is included in the reference change email (as usual), but no
    additional commit email is generated.
 
    By default, reference change emails have their "Reply-To" field set
    to the person who pushed the change, and commit emails have their
    "Reply-To" field set to the author of the commit.
+
+   [*] If either of multimailhook.refFilter(In|Ex)clusionRegex are
+       set, then the commit email will be sent the first time it is
+       pushed *to an included ref* of the repository.  If neither of
+       these are set, then by default all tags and branches are
+       included.
 
 3. Output one "announce" mail for each new annotated tag, including
    information about the tag and optionally a shortlog describing the
@@ -503,6 +509,18 @@ multimailhook.combineWhenSingleCommit
     a branch, combine the summary and commit email messages into a
     single email.
     Default: true
+
+multimailhook.refFilterInclusionRegex
+multimailhook.refFilterExclusionRegex
+
+    Regular expressions that can be used to limit refs for which email
+    updates will be sent.  It is an error to specify both an inclusion
+    and an exclusion regex.  If an inclusion regex is specified, emails
+    will only be sent for refs which match this regex.  If an exclusion
+    regex is specified, emails will be sent for all refs except those
+    that match this regex (or that match a predefined regex specific
+    to the environment, such as "^refs/notes" for most environments and
+    "^refs/notes|^refs/changes" for the gerrit environment).
 
 
 Email filtering aids

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -2746,10 +2746,11 @@ class Push(object):
             ])
         )
 
-    def __init__(self, changes, ignore_other_refs=False):
+    def __init__(self, environment, changes, ignore_other_refs=False):
         self.changes = sorted(changes, key=self._sort_key)
         self.__other_ref_sha1s = None
         self.__cached_commits_spec = {}
+        self.environment = environment
 
         if ignore_other_refs:
             self.__other_ref_sha1s = set()
@@ -2984,7 +2985,7 @@ def run_as_post_receive_hook(environment, mailer):
         changes.append(
             ReferenceChange.create(environment, oldrev, newrev, refname)
             )
-    push = Push(changes)
+    push = Push(environment, changes)
     push.send_emails(mailer, body_filter=environment.filter_body)
 
 
@@ -2997,7 +2998,7 @@ def run_as_update_hook(environment, mailer, refname, oldrev, newrev, force_send=
             refname,
             ),
         ]
-    push = Push(changes, force_send)
+    push = Push(environment, changes, force_send)
     push.send_emails(mailer, body_filter=environment.filter_body)
 
 

--- a/t/generate-test-emails
+++ b/t/generate-test-emails
@@ -21,27 +21,31 @@ test_email() {
     REFNAME="$1"
     OLDREV="$2"
     NEWREV="$3"
-    pecho "$OLDREV" "$NEWREV" "$REFNAME" | USER=pushuser "$MULTIMAIL"
+    shift 3
+    pecho "$OLDREV" "$NEWREV" "$REFNAME" | USER=pushuser "$MULTIMAIL" "$@"
 }
 
 test_create() {
     REFNAME="$1"
     NEWREV=$(git rev-parse "$REFNAME")
-    test_email "$REFNAME" "$ZEROS" "$NEWREV"
+    shift
+    test_email "$REFNAME" "$ZEROS" "$NEWREV" "$@"
 }
 
 test_update() {
     REFNAME="$1"
     OLDREV=$(git rev-parse "$2")
     NEWREV=$(git rev-parse "$REFNAME")
-    test_email "$REFNAME" "$OLDREV" "$NEWREV"
+    shift 2
+    test_email "$REFNAME" "$OLDREV" "$NEWREV" "$@"
 }
 
 test_delete() {
     REFNAME="$1"
     OLDREV=$(git rev-parse "$REFNAME")
+    shift
     git update-ref -d "$REFNAME" "$OLDREV" &&
-    test_email "$REFNAME" "$OLDREV" "$ZEROS"
+    test_email "$REFNAME" "$OLDREV" "$ZEROS" "$@"
     RETCODE=$?
     git update-ref "$REFNAME" "$OLDREV" ||
         error "Error replacing reference $REFNAME to $OLDREV"
@@ -52,8 +56,9 @@ test_rewind() {
     REFNAME="$1"
     OLDREV=$(git rev-parse "$REFNAME")
     NEWREV=$(git rev-parse "$2")
+    shift 2
     git update-ref "$REFNAME" "$NEWREV" "$OLDREV" &&
-    test_email "$REFNAME" "$OLDREV" "$NEWREV"
+    test_email "$REFNAME" "$OLDREV" "$NEWREV" "$@"
     RETCODE=$?
     git update-ref "$REFNAME" "$OLDREV" ||
         error "Error replacing reference $REFNAME to $OLDREV"
@@ -65,7 +70,8 @@ test_hook() {
     REFNAME="$1"
     OLDREV=$(git rev-parse "$2")
     NEWREV=$(git rev-parse "$REFNAME")
-    pecho "$OLDREV" "$NEWREV" "$REFNAME" | USER=pushuser "$POST_RECEIVE"
+    shift 2
+    pecho "$OLDREV" "$NEWREV" "$REFNAME" | USER=pushuser "$POST_RECEIVE" "$@"
 }
 
 verbose_do() {

--- a/t/generate-test-emails
+++ b/t/generate-test-emails
@@ -174,7 +174,12 @@ git branch feature "$f"
 verbose_do git config multimailhook.commitList 'Commit List <commitlist@example.com>'
 # Should produce no output at all
 verbose_do git config multimailhook.refFilterExclusionRegex ^refs/heads/master$
+verbose_do git config multimailhook.refFilterInclusionRegex whatever
+# Errors out
 verbose_do test_update refs/heads/master refs/heads/master^^
+verbose_do git config --unset multimailhook.refFilterInclusionRegex
+verbose_do test_update refs/heads/master refs/heads/master^^
+
 verbose_do git config --unset multimailhook.refFilterExclusionRegex
 verbose_do git config multimailhook.refFilterInclusionRegex ^refs/heads/feature$
 verbose_do test_update refs/heads/master refs/heads/master^^
@@ -183,6 +188,12 @@ verbose_do test_update refs/heads/master refs/heads/master^^
 verbose_do git config multimailhook.refFilterInclusionRegex ^refs/heads/master$
 verbose_do test_update refs/heads/master refs/heads/master^^
 verbose_do git config --unset multimailhook.refFilterInclusionRegex
+
+# Should produce a refchange email with m1 and a5 marked as new
+# and others as add
+verbose_do git config multimailhook.refFilterDoSendRegex ^refs/heads/master$
+verbose_do test_update refs/heads/master refs/heads/master^^
+verbose_do git config --unset multimailhook.refFilterDoSendRegex
 
 for o in mailinglist refchangelist announcelist commitlist; do
     verbose_do git config multimailhook."$o" ''

--- a/t/generate-test-emails
+++ b/t/generate-test-emails
@@ -171,6 +171,19 @@ test_update refs/heads/master refs/heads/foo
 verbose_do git config multimailhook.refChangeShowGraph false
 git branch feature "$f"
 
+verbose_do git config multimailhook.commitList 'Commit List <commitlist@example.com>'
+# Should produce no output at all
+verbose_do git config multimailhook.refFilterExclusionRegex ^refs/heads/master$
+verbose_do test_update refs/heads/master refs/heads/master^^
+verbose_do git config --unset multimailhook.refFilterExclusionRegex
+verbose_do git config multimailhook.refFilterInclusionRegex ^refs/heads/feature$
+verbose_do test_update refs/heads/master refs/heads/master^^
+
+# Should produce a refchange email with all commits marked as new
+verbose_do git config multimailhook.refFilterInclusionRegex ^refs/heads/master$
+verbose_do test_update refs/heads/master refs/heads/master^^
+verbose_do git config --unset multimailhook.refFilterInclusionRegex
+
 for o in mailinglist refchangelist announcelist commitlist; do
     verbose_do git config multimailhook."$o" ''
 done

--- a/t/multimail.expect
+++ b/t/multimail.expect
@@ -3668,6 +3668,300 @@ Administrator <administrator@example.com>.
 EOF
 ######################################################################
 $ git 'config' 'multimailhook.refChangeShowGraph' 'false'
+$ git 'config' 'multimailhook.commitList' 'Commit List <commitlist@example.com>'
+$ git 'config' 'multimailhook.refFilterExclusionRegex' '^refs/heads/master$'
+$ test_update 'refs/heads/master' 'refs/heads/master^^'
+$ git 'config' '--unset' 'multimailhook.refFilterExclusionRegex'
+$ git 'config' 'multimailhook.refFilterInclusionRegex' '^refs/heads/feature$'
+$ test_update 'refs/heads/master' 'refs/heads/master^^'
+$ git 'config' 'multimailhook.refFilterInclusionRegex' '^refs/heads/master$'
+$ test_update 'refs/heads/master' 'refs/heads/master^^'
+Sending notification emails to: Refchange List <refchangelist@example.com>
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: Refchange List <refchangelist@example.com>
+Subject: *test-repo* branch master updated (ebf40e1 -> 902dfe1)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+Message-ID: <...>
+From: From <from@example.com>
+Reply-To: pushuser@example.com
+X-Git-Host: fqdn.example.org
+X-Git-Repo: test-repo
+X-Git-Refname: refs/heads/master
+X-Git-Reftype: branch
+X-Git-Oldrev: ebf40e1fe61e9b74334f80b1e8af506a36ddb57f
+X-Git-Newrev: 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
+X-Git-NotificationType: ref_changed
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a change to branch master
+in repository test-repo.
+
+      from  ebf40e1   a4
+       new  f0e9a98   f1
+       new  c742b15   f2
+       new  abb8baa   f3
+       new  d245c99   m1
+       new  902dfe1   a5
+
+The 5 revisions listed above as "new" are entirely new to this
+repository and will be described in separate emails.  The revisions
+listed as "adds" were already present in the repository and have only
+been added to this reference.
+
+
+Summary of changes:
+ a.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+EOF
+######################################################################
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: Commit List <commitlist@example.com>
+Subject: *test-repo* 01/05: f1
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+From: From <from@example.com>
+Reply-To: Joe User <user@example.com>
+In-Reply-To: <...>
+References: <...>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: test-repo
+X-Git-Refname: refs/heads/master
+X-Git-Reftype: branch
+X-Git-Rev: f0e9a982738fb14c0c66097353bf2404135624fb
+X-Git-NotificationType: diff
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a commit to branch master
+in repository test-repo.
+
+commit f0e9a982738fb14c0c66097353bf2404135624fb
+Author: Joe User <user@example.com>
+Date:   Fri Feb 3 09:29:08 2012 +0100
+
+    f1
+---
+ a.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/a.txt b/a.txt
+index d00491f..8e1e71d 100644
+--- a/a.txt
++++ b/a.txt
+@@ -1 +1 @@
+-1
++f1
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+EOF
+######################################################################
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: Commit List <commitlist@example.com>
+Subject: *test-repo* 02/05: f2
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+From: From <from@example.com>
+Reply-To: Joe User <user@example.com>
+In-Reply-To: <...>
+References: <...>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: test-repo
+X-Git-Refname: refs/heads/master
+X-Git-Reftype: branch
+X-Git-Rev: c742b15e5c9cbb174294c1b3efaa959413bf4137
+X-Git-NotificationType: diff
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a commit to branch master
+in repository test-repo.
+
+commit c742b15e5c9cbb174294c1b3efaa959413bf4137
+Author: Joe User <user@example.com>
+Date:   Fri Feb 3 09:29:13 2012 +0100
+
+    f2
+---
+ a.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/a.txt b/a.txt
+index 8e1e71d..9de77c1 100644
+--- a/a.txt
++++ b/a.txt
+@@ -1 +1 @@
+-f1
++f2
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+EOF
+######################################################################
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: Commit List <commitlist@example.com>
+Subject: *test-repo* 03/05: f3
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+From: From <from@example.com>
+Reply-To: Joe User <user@example.com>
+In-Reply-To: <...>
+References: <...>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: test-repo
+X-Git-Refname: refs/heads/master
+X-Git-Reftype: branch
+X-Git-Rev: abb8baa7170a6d55bc4311cc819579a929eb0b04
+X-Git-NotificationType: diff
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a commit to branch master
+in repository test-repo.
+
+commit abb8baa7170a6d55bc4311cc819579a929eb0b04
+Author: Joe User <user@example.com>
+Date:   Fri Feb 3 09:31:22 2012 +0100
+
+    f3
+---
+ a.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/a.txt b/a.txt
+index 9de77c1..45d9e0e 100644
+--- a/a.txt
++++ b/a.txt
+@@ -1 +1 @@
+-f2
++f3
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+EOF
+######################################################################
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: Commit List <commitlist@example.com>
+Subject: *test-repo* 04/05: m1
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+From: From <from@example.com>
+Reply-To: Joe User <user@example.com>
+In-Reply-To: <...>
+References: <...>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: test-repo
+X-Git-Refname: refs/heads/master
+X-Git-Reftype: branch
+X-Git-Rev: d245c99162aff6fff4879e5d5c17d454766b45db
+X-Git-NotificationType: diff
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a commit to branch master
+in repository test-repo.
+
+commit d245c99162aff6fff4879e5d5c17d454766b45db
+Merge: ebf40e1 abb8baa
+Author: Joe User <user@example.com>
+Date:   Fri Feb 3 09:32:27 2012 +0100
+
+    m1
+
+ a.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --cc a.txt
+index b8626c4,45d9e0e..63a911f
+--- a/a.txt
++++ b/a.txt
+@@@ -1,1 -1,1 +1,1 @@@
+- 4
+ -f3
+++m1
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+EOF
+######################################################################
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: Commit List <commitlist@example.com>
+Subject: *test-repo* 05/05: a5
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+From: From <from@example.com>
+Reply-To: Joe User <user@example.com>
+In-Reply-To: <...>
+References: <...>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: test-repo
+X-Git-Refname: refs/heads/master
+X-Git-Reftype: branch
+X-Git-Rev: 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
+X-Git-NotificationType: diff
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a commit to branch master
+in repository test-repo.
+
+commit 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
+Author: Joe User <user@example.com>
+Date:   Fri Feb 3 09:32:50 2012 +0100
+
+    a5
+---
+ a.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/a.txt b/a.txt
+index 63a911f..7ed6ff8 100644
+--- a/a.txt
++++ b/a.txt
+@@ -1 +1 @@
+-m1
++5
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+EOF
+######################################################################
+$ git 'config' '--unset' 'multimailhook.refFilterInclusionRegex'
 $ git 'config' 'multimailhook.mailinglist' ''
 $ git 'config' 'multimailhook.refchangelist' ''
 $ git 'config' 'multimailhook.announcelist' ''

--- a/t/multimail.expect
+++ b/t/multimail.expect
@@ -3670,6 +3670,10 @@ EOF
 $ git 'config' 'multimailhook.refChangeShowGraph' 'false'
 $ git 'config' 'multimailhook.commitList' 'Commit List <commitlist@example.com>'
 $ git 'config' 'multimailhook.refFilterExclusionRegex' '^refs/heads/master$'
+$ git 'config' 'multimailhook.refFilterInclusionRegex' 'whatever'
+$ test_update 'refs/heads/master' 'refs/heads/master^^'
+Cannot specify both a ref inclusion and exclusion regex.
+$ git 'config' '--unset' 'multimailhook.refFilterInclusionRegex'
 $ test_update 'refs/heads/master' 'refs/heads/master^^'
 $ git 'config' '--unset' 'multimailhook.refFilterExclusionRegex'
 $ git 'config' 'multimailhook.refFilterInclusionRegex' '^refs/heads/feature$'
@@ -3962,6 +3966,153 @@ Administrator <administrator@example.com>.
 EOF
 ######################################################################
 $ git 'config' '--unset' 'multimailhook.refFilterInclusionRegex'
+$ git 'config' 'multimailhook.refFilterDoSendRegex' '^refs/heads/master$'
+$ test_update 'refs/heads/master' 'refs/heads/master^^'
+Sending notification emails to: Refchange List <refchangelist@example.com>
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: Refchange List <refchangelist@example.com>
+Subject: *test-repo* branch master updated (ebf40e1 -> 902dfe1)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+Message-ID: <...>
+From: From <from@example.com>
+Reply-To: pushuser@example.com
+X-Git-Host: fqdn.example.org
+X-Git-Repo: test-repo
+X-Git-Refname: refs/heads/master
+X-Git-Reftype: branch
+X-Git-Oldrev: ebf40e1fe61e9b74334f80b1e8af506a36ddb57f
+X-Git-Newrev: 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
+X-Git-NotificationType: ref_changed
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a change to branch master
+in repository test-repo.
+
+      from  ebf40e1   a4
+      adds  f0e9a98   f1
+      adds  c742b15   f2
+      adds  abb8baa   f3
+       new  d245c99   m1
+       new  902dfe1   a5
+
+The 2 revisions listed above as "new" are entirely new to this
+repository and will be described in separate emails.  The revisions
+listed as "adds" were already present in the repository and have only
+been added to this reference.
+
+
+Summary of changes:
+ a.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+EOF
+######################################################################
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: Commit List <commitlist@example.com>
+Subject: *test-repo* 01/02: m1
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+From: From <from@example.com>
+Reply-To: Joe User <user@example.com>
+In-Reply-To: <...>
+References: <...>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: test-repo
+X-Git-Refname: refs/heads/master
+X-Git-Reftype: branch
+X-Git-Rev: d245c99162aff6fff4879e5d5c17d454766b45db
+X-Git-NotificationType: diff
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a commit to branch master
+in repository test-repo.
+
+commit d245c99162aff6fff4879e5d5c17d454766b45db
+Merge: ebf40e1 abb8baa
+Author: Joe User <user@example.com>
+Date:   Fri Feb 3 09:32:27 2012 +0100
+
+    m1
+
+ a.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --cc a.txt
+index b8626c4,45d9e0e..63a911f
+--- a/a.txt
++++ b/a.txt
+@@@ -1,1 -1,1 +1,1 @@@
+- 4
+ -f3
+++m1
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+EOF
+######################################################################
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: Commit List <commitlist@example.com>
+Subject: *test-repo* 02/02: a5
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+From: From <from@example.com>
+Reply-To: Joe User <user@example.com>
+In-Reply-To: <...>
+References: <...>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: test-repo
+X-Git-Refname: refs/heads/master
+X-Git-Reftype: branch
+X-Git-Rev: 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
+X-Git-NotificationType: diff
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a commit to branch master
+in repository test-repo.
+
+commit 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
+Author: Joe User <user@example.com>
+Date:   Fri Feb 3 09:32:50 2012 +0100
+
+    a5
+---
+ a.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/a.txt b/a.txt
+index 63a911f..7ed6ff8 100644
+--- a/a.txt
++++ b/a.txt
+@@ -1 +1 @@
+-m1
++5
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+EOF
+######################################################################
+$ git 'config' '--unset' 'multimailhook.refFilterDoSendRegex'
 $ git 'config' 'multimailhook.mailinglist' ''
 $ git 'config' 'multimailhook.refchangelist' ''
 $ git 'config' 'multimailhook.announcelist' ''


### PR DESCRIPTION
This is a replacement for #52 by @newren . Changes:

* Rebased on master, many conflicts resolution :-(.

* Removed the command-line options. I think having a `-c` option like `git` has to set arbitrary configuration variables would be much better, and I don't want to encourage too many command-line options waiting for the feature to be implemented.

* Squashed several commits together for clarity

* Style remarks in previous PR applied

* A bit more tests

I temporarily gave up on the idea of configuration subsection. Last time we blocked a feature waiting for this, nothing ever happened. I'd still very much welcome a PR implementing this, though. The "regex" Vs "list of regex" can be dealt with later. I still think `for-each-ref`-style glob would be simpler to use, but why not have both if we ever implement glob. And we already have the regex implementation, so let's not block it.

The last point to solve before I can merge this is how to deal with the second use-case "I don't want notification commits for these refs, but I still want to keep these refs when computing the list of new commits".

Right now, the best idea I can find is to have another pair of variables like `refFilterDontSentRegex` / `refFilterDoSendRegex` that would act like this. We don't have to implement this before merging, but we need to agree on a consistent naming to avoid backward-incompatible change later. What do you think?