### PR TITLE
Mention that "tls" is a valid value for smtpEncryption option.

### DIFF
--- a/git-multimail/README
+++ b/git-multimail/README
@@ -345,7 +345,7 @@ multimailhook.mailer
 
       * multimailhook.smtpEncryption
 
-        Set the security type. Allowed values: none, ssl.
+        Set the security type. Allowed values: none, ssl, tls.
         Default=none.
 
       * multimailhook.smtpServerDebugLevel


### PR DESCRIPTION
Saying that only "ssl" was allowed was misleading, "tls" works just fine too.

---

Trivial PR just because I got scared that my latest setup of git-multimail was all for nothing because I had to send email via Google and this only works with "tls", not "ssl", which wasn't mentioned.