### PR TITLE
Add option for generating diffs in HTML format.

### DIFF
--- a/git-multimail/CHANGES
+++ b/git-multimail/CHANGES
@@ -1,3 +1,9 @@
+Release x.y.z (in progress)
+=============
+
+* New commitEmailFormat option which can be set to "html" to generate
+  simple colorized diffs using HTML for the commit emails.
+
 Release 1.2.0
 =============
 

--- a/git-multimail/README
+++ b/git-multimail/README
@@ -270,6 +270,13 @@ multimailhook.announceShortlog
     not so straightforward, then the shortlog might be confusing
     rather than useful.  Default is false.
 
+multimailhook.commitEmailFormat
+
+    The format of email messages for the individual commits, can be "text" or
+    "html". In the latter case, the emails will include diffs using colorized
+    HTML instead of plain text used by default. Note that this  currently the
+    ref change emails are always sent in plain text.
+
 multimailhook.refchangeShowGraph
 
     If this option is set to true, then summary emails about reference


### PR DESCRIPTION
Generate text/html emails with inline colorized diffs if "htmldiffs" option is
set.

This is based on the original patch from Marc Mengel (see PR #74), but was
almost completely rewritten.

Signed-off-by: Vadim Zeitlin <vadim@zeitlins.org>

----

Notes:

 1. I couldn't make this work with the mix-ins as the original PR tried to do, they are just too confusing/magic (in my defence, the original patch didn't work at all though and mine at least does work).
 1. More generally speaking, the only redeemable quality of this patch is that it works with a small amount of changes. Ideally the email generation code should be rewritten to allow having multipart messages with text and HTML parts instead. But I won't have time to do this.
 1. Similarly, diff hunks should be parsed, but I didn't find any ready to use module to do it (I hoped cdiff could be used, but it's a program, not a library) and didn't have time to do this properly myself neither.
 1. I thought about adding a test for this but couldn't untangle how the test suite worked. I thought anything TAP-based would be simple to modify, but I was wrong.
 1. I didn't find any changelog-like file to modify, so I couldn't document this change.