### PR TITLE
Implement git-multimail -c, like git -c var=val

### DIFF
--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -3434,6 +3434,14 @@ def main(args):
             ),
         )
     parser.add_option(
+        '-c', metavar="<name>=<value>", action='append',
+        help=(
+            'Pass a configuration parameter through to git.  The value given '
+            'will override values from configuration files.  See the -c option '
+            'of git(1) for more details.  (Only works with git >= 1.7.3)'
+            ),
+        )
+    parser.add_option(
         '--version', '-v', action='store_true', default=False,
         help=(
             "Display git-multimail's version"
@@ -3464,6 +3472,19 @@ def main(args):
     if options.version:
         sys.stdout.write('git-multimail version ' + get_version() + '\n')
         return
+
+    if options.c:
+        parameters = os.environ.get('GIT_CONFIG_PARAMETERS', '')
+        if parameters:
+            parameters += ' '
+        # git expects GIT_CONFIG_PARAMETERS to be of the form
+        #    "'name1=value1' 'name2=value2' 'name3=value3'"
+        # including everything inside the double quotes (but not the double
+        # quotes themselves).  Spacing is critical.  Also, if a value contains
+        # a literal single quote that quote must be represented using the
+        # four character sequence: '\''
+        parameters += ' '.join("'" + x.replace("'", "'\\''") + "'" for x in options.c)
+        os.environ['GIT_CONFIG_PARAMETERS'] = parameters
 
     config = Config('multimailhook')
 

--- a/t/generate-test-emails
+++ b/t/generate-test-emails
@@ -94,11 +94,7 @@ verbose_do() {
 }
 
 test_create refs/heads/master
-verbose_do git config multimailhook.refChangeShowGraph true
-verbose_do git config multimailhook.graphOpts '--oneline'
-test_update refs/heads/master refs/heads/master^^
-verbose_do git config multimailhook.refChangeShowGraph false
-verbose_do git config --unset multimailhook.graphOpts
+test_update refs/heads/master refs/heads/master^^ -c multimailhook.refChangeShowGraph=true -c multimailhook.graphOpts=--oneline
 test_update refs/heads/master refs/heads/feature
 test_delete refs/heads/master
 test_rewind refs/heads/master refs/heads/master^^
@@ -114,9 +110,7 @@ verbose_do git config multimailhook.refchangelist 'Commit List <commitlist@examp
 test_update refs/heads/release refs/heads/release^
 verbose_do git config multimailhook.refchangelist 'Refchange List <refchangelist@example.com>'
 
-verbose_do git config multimailhook.refChangeShowGraph true
-test_rewind refs/heads/release refs/heads/release^^
-verbose_do git config multimailhook.refChangeShowGraph false
+test_rewind refs/heads/release refs/heads/release^^ -c multimailhook.refChangeShowGraph=true
 
 test_create refs/heads/feature
 test_update refs/heads/feature refs/heads/feature^^^
@@ -175,27 +169,18 @@ git branch feature "$f"
 
 verbose_do git config multimailhook.commitList 'Commit List <commitlist@example.com>'
 # Should produce no output at all
-verbose_do git config multimailhook.refFilterExclusionRegex ^refs/heads/master$
-verbose_do git config multimailhook.refFilterInclusionRegex whatever
 # Errors out
-verbose_do test_update refs/heads/master refs/heads/master^^
-verbose_do git config --unset multimailhook.refFilterInclusionRegex
-verbose_do test_update refs/heads/master refs/heads/master^^
+verbose_do test_update refs/heads/master refs/heads/master^^ -c multimailhook.refFilterExclusionRegex=^refs/heads/master$ -c multimailhook.refFilterInclusionRegex=whatever
+verbose_do test_update refs/heads/master refs/heads/master^^ -c multimailhook.refFilterExclusionRegex=^refs/heads/master$
 
-verbose_do git config --unset multimailhook.refFilterExclusionRegex
-verbose_do git config multimailhook.refFilterInclusionRegex ^refs/heads/feature$
-verbose_do test_update refs/heads/master refs/heads/master^^
+verbose_do test_update refs/heads/master refs/heads/master^^ -c multimailhook.refFilterInclusionRegex=^refs/heads/feature$
 
 # Should produce a refchange email with all commits marked as new
-verbose_do git config multimailhook.refFilterInclusionRegex ^refs/heads/master$
-verbose_do test_update refs/heads/master refs/heads/master^^
-verbose_do git config --unset multimailhook.refFilterInclusionRegex
+verbose_do test_update refs/heads/master refs/heads/master^^ -c multimailhook.refFilterInclusionRegex=^refs/heads/master$
 
 # Should produce a refchange email with m1 and a5 marked as new
 # and others as add
-verbose_do git config multimailhook.refFilterDoSendRegex ^refs/heads/master$
-verbose_do test_update refs/heads/master refs/heads/master^^
-verbose_do git config --unset multimailhook.refFilterDoSendRegex
+verbose_do test_update refs/heads/master refs/heads/master^^ -c multimailhook.refFilterDoSendRegex=^refs/heads/master$
 
 # Test for Gerrit environment
 # (no verbose_do since "$MULTIMAIL" changes from a machine to another)

--- a/t/multimail.expect
+++ b/t/multimail.expect
@@ -288,8 +288,6 @@ To stop receiving notification emails like this one, please contact
 Administrator <administrator@example.com>.
 EOF
 ######################################################################
-$ git 'config' 'multimailhook.refChangeShowGraph' 'true'
-$ git 'config' 'multimailhook.graphOpts' '--oneline'
 Sending notification emails to: Refchange List <refchangelist@example.com>
 ######################################################################
 /usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
@@ -443,8 +441,6 @@ To stop receiving notification emails like this one, please contact
 Administrator <administrator@example.com>.
 EOF
 ######################################################################
-$ git 'config' 'multimailhook.refChangeShowGraph' 'false'
-$ git 'config' '--unset' 'multimailhook.graphOpts'
 Sending notification emails to: Refchange List <refchangelist@example.com>
 ######################################################################
 /usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
@@ -1256,7 +1252,6 @@ Administrator <administrator@example.com>.
 EOF
 ######################################################################
 $ git 'config' 'multimailhook.refchangelist' 'Refchange List <refchangelist@example.com>'
-$ git 'config' 'multimailhook.refChangeShowGraph' 'true'
 Sending notification emails to: Refchange List <refchangelist@example.com>
 ######################################################################
 /usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
@@ -1314,7 +1309,6 @@ To stop receiving notification emails like this one, please contact
 Administrator <administrator@example.com>.
 EOF
 ######################################################################
-$ git 'config' 'multimailhook.refChangeShowGraph' 'false'
 Sending notification emails to: Refchange List <refchangelist@example.com>
 ######################################################################
 /usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
@@ -3742,17 +3736,11 @@ EOF
 ######################################################################
 $ git 'config' 'multimailhook.refChangeShowGraph' 'false'
 $ git 'config' 'multimailhook.commitList' 'Commit List <commitlist@example.com>'
-$ git 'config' 'multimailhook.refFilterExclusionRegex' '^refs/heads/master$'
-$ git 'config' 'multimailhook.refFilterInclusionRegex' 'whatever'
-$ test_update 'refs/heads/master' 'refs/heads/master^^'
+$ test_update 'refs/heads/master' 'refs/heads/master^^' '-c' 'multimailhook.refFilterExclusionRegex=^refs/heads/master$' '-c' 'multimailhook.refFilterInclusionRegex=whatever'
 Cannot specify both a ref inclusion and exclusion regex.
-$ git 'config' '--unset' 'multimailhook.refFilterInclusionRegex'
-$ test_update 'refs/heads/master' 'refs/heads/master^^'
-$ git 'config' '--unset' 'multimailhook.refFilterExclusionRegex'
-$ git 'config' 'multimailhook.refFilterInclusionRegex' '^refs/heads/feature$'
-$ test_update 'refs/heads/master' 'refs/heads/master^^'
-$ git 'config' 'multimailhook.refFilterInclusionRegex' '^refs/heads/master$'
-$ test_update 'refs/heads/master' 'refs/heads/master^^'
+$ test_update 'refs/heads/master' 'refs/heads/master^^' '-c' 'multimailhook.refFilterExclusionRegex=^refs/heads/master$'
+$ test_update 'refs/heads/master' 'refs/heads/master^^' '-c' 'multimailhook.refFilterInclusionRegex=^refs/heads/feature$'
+$ test_update 'refs/heads/master' 'refs/heads/master^^' '-c' 'multimailhook.refFilterInclusionRegex=^refs/heads/master$'
 Sending notification emails to: Refchange List <refchangelist@example.com>
 ######################################################################
 /usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
@@ -4044,9 +4032,7 @@ To stop receiving notification emails like this one, please contact
 Administrator <administrator@example.com>.
 EOF
 ######################################################################
-$ git 'config' '--unset' 'multimailhook.refFilterInclusionRegex'
-$ git 'config' 'multimailhook.refFilterDoSendRegex' '^refs/heads/master$'
-$ test_update 'refs/heads/master' 'refs/heads/master^^'
+$ test_update 'refs/heads/master' 'refs/heads/master^^' '-c' 'multimailhook.refFilterDoSendRegex=^refs/heads/master$'
 Sending notification emails to: Refchange List <refchangelist@example.com>
 ######################################################################
 /usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
@@ -4194,7 +4180,6 @@ To stop receiving notification emails like this one, please contact
 Administrator <administrator@example.com>.
 EOF
 ######################################################################
-$ git 'config' '--unset' 'multimailhook.refFilterDoSendRegex'
 $ git_multimail.py --stdout --oldrev refs/heads/master^ --newrev refs/heads/master --refname master --project demo-project --submitter Sub Mitter (sub.mitter@example.com)
 Sending notification emails to: Refchange List <refchangelist@example.com>
 ===========================================================================


### PR DESCRIPTION
This implements the feature request in issue #102.

Two caveats/concerns:

I was wondering whether the setting of GIT_CONFIG_PARAMETERS would be better off done in the Config class, but there is not only one of those created from main() but also directly from the Environment class (and possibly more in the future), making it seem slightly awkward to pass all the necessary data down to all instantiations.  If you have alternative ideas about where to move the setting of this environment variable, I'm happy to move it around.

Also, I tried simplifying a few more tests and was surprised to learn that both GIT_CONFIG_PARAMETERS and -c values on the command line passed to git will cause git to add a second value for the field rather than override the existing value (e.g. if multimail.refchangelist is already set and you run git -c multimail.refchangelist=foo config --list, you'll see two values printed for multimail.refchangelist.  Same can be seen with the simple user.name or core.bare.  For me, this resulted in emails being sent to two lists.).  This appears to be contrary to the git(1) manpage, but I duplicated with both git 1.8.3.1 and 2.5.0, so maybe I'm misunderstanding something?  Or maybe git has a long-standing bug that no one has noticed yet?