### PR TITLE
Allow commitList and other *List option take a special "none" value.

### DIFF
--- a/doc/gitolite.rst
+++ b/doc/gitolite.rst
@@ -68,13 +68,18 @@ With gitolite, the syntax ``config multimailhook.commitList = ""``
 unsets the variable instead of setting it to an empty string (see
 `here
 <http://gitolite.com/gitolite/git-config.html#an-important-warning-about-deleting-a-config-line>`__).
-As a result, there is no way to set a variable to the empty string. As
-a workaround, one can use ``" "`` (a single space) instead of ``""``.
+As a result, there is no way to set a variable to the empty string.
+In all most places where an empty value is required, git-multimail
+now allows to specify special ``"none"`` value (case-sensitive) to
+mean the same.
+
+Alternatively, one can use ``" "`` (a single space) instead of ``""``.
 In most cases (in particular ``multimailhook.*List`` variables), this
 will be equivalent to an empty string.
 
-If you have a use-case where ``" "`` is not an acceptable value and
-you need ``""`` instead, please report it as a bug to git-multimail.
+If you have a use-case where ``"none"`` is not an acceptable value and
+you need ``" "`` or  ``""`` instead, please report it as a bug to
+git-multimail.
 
 Allowing Regular Expressions in Configuration
 .............................................

--- a/git-multimail/README
+++ b/git-multimail/README
@@ -236,8 +236,8 @@ multimailhook.refchangeList
     reference changes should be sent, as RFC 2822 email addresses
     separated by commas.  This configuration option can be
     multivalued.  The default is the value in
-    multimailhook.mailingList.  Set this value to the empty string to
-    prevent reference change emails from being sent even if
+    multimailhook.mailingList.  Set this value to "none" (or the empty
+    string) to prevent reference change emails from being sent even if
     multimailhook.mailingList is set.
 
 multimailhook.announceList
@@ -246,9 +246,9 @@ multimailhook.announceList
     tags should be sent, as RFC 2822 email addresses separated by
     commas.  This configuration option can be multivalued.  The
     default is the value in multimailhook.refchangeList or
-    multimailhook.mailingList.  Set this value to the empty string to
-    prevent annotated tag announcement emails from being sent even if
-    one of the other values is set.
+    multimailhook.mailingList.  Set this value to "none" (or the empty
+    string) to prevent annotated tag announcement emails from being sent
+    even if one of the other values is set.
 
 multimailhook.commitList
 
@@ -256,7 +256,7 @@ multimailhook.commitList
     commits should be sent, as RFC 2822 email addresses separated by
     commas.  This configuration option can be multivalued.  The
     default is the value in multimailhook.mailingList.  Set this value
-    to the empty string to prevent notification emails about
+    to "none" (or the empty string) to prevent notification emails about
     individual commits from being sent even if
     multimailhook.mailingList is set.
 

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -2606,7 +2606,11 @@ class ConfigRecipientsEnvironmentMixin(
         for name in names:
             lines = config.get_all(name)
             if lines is not None:
-                return ', '.join(line.strip() for line in lines)
+                lines = [line.strip() for line in lines]
+                # Single "none" is a special value equivalen to empty string.
+                if lines == ['none']:
+                    lines = ['']
+                return ', '.join(lines)
         else:
             return ''
 

--- a/t/test-env
+++ b/t/test-env
@@ -99,7 +99,7 @@ class ConfigTest(unittest.TestCase):
         """Test get_recipients() method"""
         config = self.ConfigMock({'scancommitforcc': None},
                                  {'mailinglist': ('foo@example.com',),
-                                  'commitlist': (''),
+                                  'commitlist': ('',),
                                   'refchangelist': ('one@example.com', 'two@example.com'),
                                   'announcelist': None})
         cm = git_multimail.ConfigRecipientsEnvironmentMixin(config)

--- a/t/test-env
+++ b/t/test-env
@@ -110,6 +110,20 @@ class ConfigTest(unittest.TestCase):
         # Empty string specified => result empty
         self.assertEquals(cm.get_revision_recipients(None), '')
 
+    def test_get_recipients_none(self):
+        """Test get_recipients()'s handling of 'none' special value"""
+        config = self.ConfigMock({'scancommitforcc': None},
+                                 {'mailinglist': ('foo@example.com',),
+                                  'commitlist': ('none',),
+                                  'refchangelist': ('none', 'two@example.com'),
+                                  'announcelist': None})
+        cm = git_multimail.ConfigRecipientsEnvironmentMixin(config)
+
+        # 'none' string specified => result empty
+        self.assertEquals(cm.get_revision_recipients(None), '')
+        # But only single 'none' works this way
+        self.assertEquals(cm.get_refchange_recipients(None), 'none, two@example.com')
+
 
 class EnvTest(unittest.TestCase):
     def __init__(


### PR DESCRIPTION
This is an alias for an empty value for those options, and added to work
around issues with some git frontends (e.g. gitolite) when dealing with
empty values. "none" value should be sole value for an option, and matched
case-sensitively.

Signed-off-by: Paul Sokolovsky <paul.sokolovsky@linaro.org>