### PR TITLE
UTF-8 command line (2)

### DIFF
--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 __version__ = '1.2.dev'
 
@@ -3494,6 +3494,13 @@ def compute_gerrit_options(options, args, required_gerrit_options):
                                     options.refname))):
         options.refname = 'refs/heads/' + options.refname
 
+    # Convert each string option unicode for Python3.
+    if PYTHON3:
+        opts = ['environment', 'recipients', 'oldrev', 'newrev', 'refname', 'project', 'submitter', 'stash-user', 'stash-repo']
+        for opt in opts:
+            obj = getattr(options, opt)
+            setattr(options, opt, obj.encode('utf-8', 'surrogateescape').decode('utf-8', 'replace'))
+
     # New revisions can appear in a gerrit repository either due to someone
     # pushing directly (in which case options.submitter will be set), or they
     # can press "Submit this patchset" in the web UI for some CR (in which
@@ -3523,13 +3530,6 @@ def compute_gerrit_options(options, args, required_gerrit_options):
                                    '--format=%cN%n%aN <%aE>', options.newrev])
         if rev_info and rev_info[0] == 'Gerrit Code Review':
             options.submitter = rev_info[1]
-
-    # Convert each string option unicode for Python3.
-    if PYTHON3:
-        opts = ['environment', 'recipients', 'oldrev', 'newrev', 'refname', 'project', 'submitter', 'stash-user', 'stash-repo']
-        for opt in opts:
-            obj = getattr(options, opt)
-            setattr(options, opt, obj.encode('utf-8', 'surrogateescape').decode('utf-8', 'replace'))
 
     # We pass back refname, oldrev, newrev as args because then the
     # gerrit ref-updated hook is much like the git update hook

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -3508,9 +3508,6 @@ def compute_gerrit_options(options, args, required_gerrit_options):
         # The submitter argument is almost an RFC 2822 email address; change it
         # from 'User Name (email@domain)' to 'User Name <email@domain>' so it is
         options.submitter = options.submitter.replace('(', '<').replace(')', '>')
-        # Convert to unicode for Python3.
-        if PYTHON3:
-            options.submitter = options.submitter.encode('utf-8', 'surrogateescape').decode('utf-8', 'replace')
     else:
         update_method = 'submitted'
         # Gerrit knew who submitted this patchset, but threw that information
@@ -3526,6 +3523,13 @@ def compute_gerrit_options(options, args, required_gerrit_options):
                                    '--format=%cN%n%aN <%aE>', options.newrev])
         if rev_info and rev_info[0] == 'Gerrit Code Review':
             options.submitter = rev_info[1]
+
+    # Convert each string option unicode for Python3.
+    if PYTHON3:
+        opts = ['environment', 'recipients', 'oldrev', 'newrev', 'refname', 'project', 'submitter', 'stash-user', 'stash-repo']
+        for opt in opts:
+            obj = getattr(options, opt)
+            setattr(options, opt, obj.encode('utf-8', 'surrogateescape').decode('utf-8', 'replace'))
 
     # We pass back refname, oldrev, newrev as args because then the
     # gerrit ref-updated hook is much like the git update hook

--- a/t/email-content.d/gerrit
+++ b/t/email-content.d/gerrit
@@ -1,4 +1,4 @@
-$ git_multimail.py --stdout --oldrev refs/heads/master^ --newrev refs/heads/master --refname master --project demo-project --submitter Sûb Mitter (sub.mitter@example.com)
+$ git_multimail.py --stdout --oldrev refs/heads/master^ --newrev refs/heads/master --refname master --project démo-project --submitter Sûb Mitter (sub.mitter@example.com)
 Sending notification emails to: Refchange List <refchangelist@example.com>
 ===========================================================================
 Date: ...
@@ -11,7 +11,7 @@ Message-ID: <...>
 From: =?utf-8?q?S=C3=BBb_Mitter?= <sub.mitter@example.com>
 Reply-To: =?utf-8?q?S=C3=BBb_Mitter?= <sub.mitter@example.com>
 X-Git-Host: fqdn.example.org
-X-Git-Repo: demo-project
+X-Git-Repo: =?utf-8?q?d=C3=A9mo-project?=
 X-Git-Refname: refs/heads/master
 X-Git-Reftype: branch
 X-Git-Oldrev: d245c99162aff6fff4879e5d5c17d454766b45db
@@ -23,7 +23,7 @@ Auto-Submitted: auto-generated
 This is an automated email from the git hooks/post-receive script.
 
 Sûb Mitter pushed a change to branch master
-in repository demo-project.
+in repository démo-project.
 
       from  d245c99   m1
        new  902dfe1   a5
@@ -54,7 +54,7 @@ Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
 X-Git-Host: fqdn.example.org
-X-Git-Repo: demo-project
+X-Git-Repo: =?utf-8?q?d=C3=A9mo-project?=
 X-Git-Refname: refs/heads/master
 X-Git-Reftype: branch
 X-Git-Rev: 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
@@ -65,7 +65,7 @@ Auto-Submitted: auto-generated
 This is an automated email from the git hooks/post-receive script.
 
 Sûb Mitter pushed a commit to branch master
-in repository demo-project.
+in repository démo-project.
 
 commit 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
 Author: Joe User <user@example.com>

--- a/t/email-content.t
+++ b/t/email-content.t
@@ -144,8 +144,8 @@ test_email_content '' 'test_when_finished "git checkout master"' \
 
 test_email_content 'Gerrit environment' gerrit '
 	# (no verbose_do since "$MULTIMAIL" changes from a machine to another)
-	echo \$ git_multimail.py --stdout --oldrev refs/heads/master^ --newrev refs/heads/master --refname master --project demo-project --submitter "Sûb Mitter (sub.mitter@example.com)" &&
-	  "$PYTHON" "$MULTIMAIL" --stdout --oldrev refs/heads/master^ --newrev refs/heads/master --refname master --project demo-project --submitter "Sûb Mitter (sub.mitter@example.com)" >out &&
+	echo \$ git_multimail.py --stdout --oldrev refs/heads/master^ --newrev refs/heads/master --refname master --project démo-project --submitter "Sûb Mitter (sub.mitter@example.com)" &&
+	  "$PYTHON" "$MULTIMAIL" --stdout --oldrev refs/heads/master^ --newrev refs/heads/master --refname master --project démo-project --submitter "Sûb Mitter (sub.mitter@example.com)" >out &&
 	RETCODE=$? &&
 	cat out &&
 	test $RETCODE = 0 &&


### PR DESCRIPTION
Allow for all non-ASCII command line options in Python3, testing for failures with the --project, on top of the currently tested --submitter option.