### PR TITLE
Don't output debug message when using SMTP authentication

### DIFF
--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -1920,7 +1920,6 @@ class SMTPMailer(Mailer):
     def send(self, lines, to_addrs):
         try:
             if self.username or self.password:
-                sys.stderr.write("*** Authenticating as %s ***\n" % self.username)
                 self.smtp.login(self.username, self.password)
             msg = ''.join(lines)
             # turn comma-separated list into Python list if needed.


### PR DESCRIPTION
This "Authenticating as ..." message was added, probably accidentally, in
30d589e, but is generally useless and it's annoying to see it for every push,
just remove it.