### PR TITLE
don't write 'Date:' in generated commit emails

### DIFF
--- a/git-multimail/README
+++ b/git-multimail/README
@@ -483,6 +483,15 @@ multimailhook.commitLogOpts
     --stat -p --cc``.  Shell quoting is allowed; see
     multimailhook.logOpts for details.
 
+multimailhook.dateSubstitute
+
+    String to use as a substitute for ``Date:`` in the output of ``git
+    log`` while formatting commit messages. This is usefull to avoid
+    emitting a line that can be interpreted by mailers as the start of
+    a cited message (Zimbra webmail in particular). Defaults to
+    ``CommitDate: ``. Set to an empty string or ``none`` to deactivate
+    the behavior.
+
 multimailhook.emailDomain
 
     Domain name appended to the username of the person doing the push

--- a/t/email-content.d/accent
+++ b/t/email-content.d/accent
@@ -74,7 +74,7 @@ in repository test-repo.
 
 commit efcb618216061d6db40469f37a0ed520a81b0d75
 Author: Sébastien <sebastien@example.com>
-Date:   Sat Mar 3 11:46:40 1973 +0200
+AuthorDate: Sat Mar 3 11:46:40 1973 +0200
 
     Message accentué
 ---

--- a/t/email-content.d/all
+++ b/t/email-content.d/all
@@ -82,7 +82,7 @@ in repository test-repo.
 commit d245c99162aff6fff4879e5d5c17d454766b45db
 Merge: ebf40e1 abb8baa
 Author: Joe User <user@example.com>
-Date:   Fri Feb 3 09:32:27 2012 +0100
+AuthorDate: Fri Feb 3 09:32:27 2012 +0100
 
     m1
 
@@ -131,7 +131,7 @@ in repository test-repo.
 
 commit 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
 Author: Joe User <user@example.com>
-Date:   Fri Feb 3 09:32:50 2012 +0100
+AuthorDate: Fri Feb 3 09:32:50 2012 +0100
 
     a5
 ---
@@ -246,7 +246,7 @@ in repository test-repo.
 
 commit 50d684ad4a020a5b356c12cde0bbce01014f90d5
 Author: Joe User <user@example.com>
-Date:   Fri Feb 3 09:26:47 2012 +0100
+AuthorDate: Fri Feb 3 09:26:47 2012 +0100
 
     a2
 ---
@@ -294,7 +294,7 @@ in repository test-repo.
 
 commit 012fc788c644eebb6f0dc54489d642dec24878db
 Author: Joe User <user@example.com>
-Date:   Fri Feb 3 09:26:54 2012 +0100
+AuthorDate: Fri Feb 3 09:26:54 2012 +0100
 
     a3
 ---
@@ -342,7 +342,7 @@ in repository test-repo.
 
 commit ebf40e1fe61e9b74334f80b1e8af506a36ddb57f
 Author: Joe User <user@example.com>
-Date:   Fri Feb 3 09:27:31 2012 +0100
+AuthorDate: Fri Feb 3 09:27:31 2012 +0100
 
     a4
 ---
@@ -391,7 +391,7 @@ in repository test-repo.
 commit d245c99162aff6fff4879e5d5c17d454766b45db
 Merge: ebf40e1 abb8baa
 Author: Joe User <user@example.com>
-Date:   Fri Feb 3 09:32:27 2012 +0100
+AuthorDate: Fri Feb 3 09:32:27 2012 +0100
 
     m1
 
@@ -440,7 +440,7 @@ in repository test-repo.
 
 commit 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
 Author: Joe User <user@example.com>
-Date:   Fri Feb 3 09:32:50 2012 +0100
+AuthorDate: Fri Feb 3 09:32:50 2012 +0100
 
     a5
 ---
@@ -745,7 +745,7 @@ in repository test-repo.
 
 commit 5f26bd17b128b6f251334af774ba502a6f590fca
 Author: Joe User <user@example.com>
-Date:   Fri Feb 3 09:28:37 2012 +0100
+AuthorDate: Fri Feb 3 09:28:37 2012 +0100
 
     r3
 ---
@@ -793,7 +793,7 @@ in repository test-repo.
 
 commit cd654633ad4dfb51961a420fca63dca6e4e3d7ac
 Author: Joe User <user@example.com>
-Date:   Fri Feb 3 09:34:40 2012 +0100
+AuthorDate: Fri Feb 3 09:34:40 2012 +0100
 
     r4
 ---
@@ -886,7 +886,7 @@ in repository test-repo.
 
 commit cd654633ad4dfb51961a420fca63dca6e4e3d7ac
 Author: Joe User <user@example.com>
-Date:   Fri Feb 3 09:34:40 2012 +0100
+MyDate: Fri Feb 3 09:34:40 2012 +0100
 
     r4
 ---
@@ -1092,7 +1092,7 @@ in repository test-repo.
 
 commit 7a9800a4ba059cf9962b8a8d4d823a4e8f2cae2a
 Author: Joe User <user@example.com>
-Date:   Fri Feb 3 09:31:44 2012 +0100
+AuthorDate: Fri Feb 3 09:31:44 2012 +0100
 
     f4
 ---
@@ -1140,7 +1140,7 @@ in repository test-repo.
 
 commit 47ef1f8bb115409dc2d7ac878360df3823198d2b
 Author: Joe User <user@example.com>
-Date:   Fri Feb 3 09:33:08 2012 +0100
+AuthorDate: Fri Feb 3 09:33:08 2012 +0100
 
     f5
 ---
@@ -1235,7 +1235,7 @@ in repository test-repo.
 
 commit 7a9800a4ba059cf9962b8a8d4d823a4e8f2cae2a
 Author: Joe User <user@example.com>
-Date:   Fri Feb 3 09:31:44 2012 +0100
+AuthorDate: Fri Feb 3 09:31:44 2012 +0100
 
     f4
 ---
@@ -1283,7 +1283,7 @@ in repository test-repo.
 
 commit 47ef1f8bb115409dc2d7ac878360df3823198d2b
 Author: Joe User <user@example.com>
-Date:   Fri Feb 3 09:33:08 2012 +0100
+AuthorDate: Fri Feb 3 09:33:08 2012 +0100
 
     f5
 ---
@@ -1470,7 +1470,7 @@ in repository test-repo.
 
 commit 25d99c94a2fa9b1e1888faa63836f910fbfe773e
 Author: Joe User <user@example.com>
-Date:   Sat Jan 26 07:39:22 2013 +0100
+AuthorDate: Sat Jan 26 07:39:22 2013 +0100
 
     x1
 ---
@@ -1518,7 +1518,7 @@ in repository test-repo.
 
 commit cf3c5decbcf03c567cdcc48f054441943013e121
 Author: Joe User <user@example.com>
-Date:   Sat Jan 26 07:39:39 2013 +0100
+AuthorDate: Sat Jan 26 07:39:39 2013 +0100
 
     x2
 ---
@@ -1638,7 +1638,7 @@ in repository test-repo.
 
 commit 25d99c94a2fa9b1e1888faa63836f910fbfe773e
 Author: Joe User <user@example.com>
-Date:   Sat Jan 26 07:39:22 2013 +0100
+AuthorDate: Sat Jan 26 07:39:22 2013 +0100
 
     x1
 ---
@@ -1686,7 +1686,7 @@ in repository test-repo.
 
 commit cf3c5decbcf03c567cdcc48f054441943013e121
 Author: Joe User <user@example.com>
-Date:   Sat Jan 26 07:39:39 2013 +0100
+AuthorDate: Sat Jan 26 07:39:39 2013 +0100
 
     x2
 ---
@@ -1822,7 +1822,7 @@ in repository test-repo.
 
 commit ce88e4233b43b275d24695813d0bae1460a8f1b8
 Author: Joël User <user@example.com>
-Date:   Sat Jan 26 07:43:14 2013 +0100
+AuthorDate: Sat Jan 26 07:43:14 2013 +0100
 
     b1
 ---
@@ -1941,7 +1941,7 @@ in repository test-repo.
 
 commit ce88e4233b43b275d24695813d0bae1460a8f1b8
 Author: Joël User <user@example.com>
-Date:   Sat Jan 26 07:43:14 2013 +0100
+AuthorDate: Sat Jan 26 07:43:14 2013 +0100
 
     b1
 ---
@@ -2082,7 +2082,7 @@ in repository test-repo.
 commit d245c99162aff6fff4879e5d5c17d454766b45db
 Merge: ebf40e1 abb8baa
 Author: Joe User <user@example.com>
-Date:   Fri Feb 3 09:32:27 2012 +0100
+AuthorDate: Fri Feb 3 09:32:27 2012 +0100
 
     m1
 
@@ -2131,7 +2131,7 @@ in repository test-repo.
 
 commit 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
 Author: Joe User <user@example.com>
-Date:   Fri Feb 3 09:32:50 2012 +0100
+AuthorDate: Fri Feb 3 09:32:50 2012 +0100
 
     a5
 ---
@@ -2231,7 +2231,7 @@ in repository test-repo.
 
 commit 919426837aa07c18459a0acc0f789b6a8cd8fb80
 Author: Matthieu Moy <Matthieu.Moy@imag.fr>
-Date:   Sun May 24 19:57:13 2015 +0200
+AuthorDate: Sun May 24 19:57:13 2015 +0200
 
     Subject line
     
@@ -2284,7 +2284,7 @@ in repository test-repo.
 
 commit 850c489cf431841cf428e00fc8285456682a9d13
 Author: Matthieu Moy <Matthieu.Moy@imag.fr>
-Date:   Sun May 24 19:58:34 2015 +0200
+AuthorDate: Sun May 24 19:58:34 2015 +0200
 
     Another subject line
     
@@ -2337,7 +2337,7 @@ in repository test-repo.
 
 commit 8e11f7c6a6a86d37ac1f3e9ce6ec7d1399412c17
 Author: Matthieu Moy <Matthieu.Moy@imag.fr>
-Date:   Sun May 24 20:19:12 2015 +0200
+AuthorDate: Sun May 24 20:19:12 2015 +0200
 
     Commit without Cc: line.
     
@@ -2474,7 +2474,7 @@ in repository test-repo.
 
 commit 919426837aa07c18459a0acc0f789b6a8cd8fb80
 Author: Matthieu Moy <Matthieu.Moy@imag.fr>
-Date:   Sun May 24 19:57:13 2015 +0200
+AuthorDate: Sun May 24 19:57:13 2015 +0200
 
     Subject line
     
@@ -2526,7 +2526,7 @@ in repository test-repo.
 
 commit 850c489cf431841cf428e00fc8285456682a9d13
 Author: Matthieu Moy <Matthieu.Moy@imag.fr>
-Date:   Sun May 24 19:58:34 2015 +0200
+AuthorDate: Sun May 24 19:58:34 2015 +0200
 
     Another subject line
     

--- a/t/email-content.d/annotated-tag-content
+++ b/t/email-content.d/annotated-tag-content
@@ -85,7 +85,7 @@ in repository test-repo.
 
 commit 8fe34ad1d135ff2d216e5b1b98be5817943c9622
 Author: Joe User <user@example.com>
-Date:   Sat Jun 30 13:46:41 2012 +0200
+AuthorDate: Sat Jun 30 13:46:41 2012 +0200
 
     t1
 ---
@@ -133,7 +133,7 @@ in repository test-repo.
 
 commit fe0ff82b4b647afd6aa5f85362f95207639e76b1
 Author: Joe User <user@example.com>
-Date:   Sat Jun 30 13:46:50 2012 +0200
+AuthorDate: Sat Jun 30 13:46:50 2012 +0200
 
     t2
 ---
@@ -270,7 +270,7 @@ in repository test-repo.
 
 commit 8fe34ad1d135ff2d216e5b1b98be5817943c9622
 Author: Joe User <user@example.com>
-Date:   Sat Jun 30 13:46:41 2012 +0200
+AuthorDate: Sat Jun 30 13:46:41 2012 +0200
 
     t1
 ---
@@ -318,7 +318,7 @@ in repository test-repo.
 
 commit fe0ff82b4b647afd6aa5f85362f95207639e76b1
 Author: Joe User <user@example.com>
-Date:   Sat Jun 30 13:46:50 2012 +0200
+AuthorDate: Sat Jun 30 13:46:50 2012 +0200
 
     t2
 ---

--- a/t/email-content.d/create-master
+++ b/t/email-content.d/create-master
@@ -74,7 +74,7 @@ in repository test-repo.
 
 commit 50d684ad4a020a5b356c12cde0bbce01014f90d5
 Author: Joe User <user@example.com>
-Date:   Fri Feb 3 09:26:47 2012 +0100
+AuthorDate: Fri Feb 3 09:26:47 2012 +0100
 
     a2
 ---
@@ -122,7 +122,7 @@ in repository test-repo.
 
 commit 012fc788c644eebb6f0dc54489d642dec24878db
 Author: Joe User <user@example.com>
-Date:   Fri Feb 3 09:26:54 2012 +0100
+AuthorDate: Fri Feb 3 09:26:54 2012 +0100
 
     a3
 ---
@@ -170,7 +170,7 @@ in repository test-repo.
 
 commit ebf40e1fe61e9b74334f80b1e8af506a36ddb57f
 Author: Joe User <user@example.com>
-Date:   Fri Feb 3 09:27:31 2012 +0100
+AuthorDate: Fri Feb 3 09:27:31 2012 +0100
 
     a4
 ---
@@ -219,7 +219,7 @@ in repository test-repo.
 commit d245c99162aff6fff4879e5d5c17d454766b45db
 Merge: ebf40e1 abb8baa
 Author: Joe User <user@example.com>
-Date:   Fri Feb 3 09:32:27 2012 +0100
+AuthorDate: Fri Feb 3 09:32:27 2012 +0100
 
     m1
 
@@ -268,7 +268,7 @@ in repository test-repo.
 
 commit 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
 Author: Joe User <user@example.com>
-Date:   Fri Feb 3 09:32:50 2012 +0100
+AuthorDate: Fri Feb 3 09:32:50 2012 +0100
 
     a5
 ---

--- a/t/email-content.d/gerrit
+++ b/t/email-content.d/gerrit
@@ -69,7 +69,7 @@ in repository démo-project.
 
 commit 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
 Author: Joe User <user@example.com>
-Date:   Fri Feb 3 09:32:50 2012 +0100
+AuthorDate: Fri Feb 3 09:32:50 2012 +0100
 
     a5
 ---
@@ -159,7 +159,7 @@ in repository demo-project.
 
 commit 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
 Author: Joe User <user@example.com>
-Date:   Fri Feb 3 09:32:50 2012 +0100
+AuthorDate: Fri Feb 3 09:32:50 2012 +0100
 
     a5
 ---

--- a/t/email-content.d/html
+++ b/t/email-content.d/html
@@ -78,7 +78,7 @@ in repository test-repo.
 <pre style='margin:0'>commit d245c99162aff6fff4879e5d5c17d454766b45db</pre>
 <pre style='margin:0'>Merge: ebf40e1 abb8baa</pre>
 <pre style='margin:0'>Author: Joe User &lt;user@example.com&gt;</pre>
-<pre style='margin:0'>Date:   Fri Feb 3 09:32:27 2012 +0100</pre>
+<pre style='margin:0'>AuthorDate: Fri Feb 3 09:32:27 2012 +0100</pre>
 <br>
 <pre style='margin:0'>    m1</pre>
 <br>
@@ -131,7 +131,7 @@ in repository test-repo.
 </pre>
 <pre style='margin:0'>commit 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d</pre>
 <pre style='margin:0'>Author: Joe User &lt;user@example.com&gt;</pre>
-<pre style='margin:0'>Date:   Fri Feb 3 09:32:50 2012 +0100</pre>
+<pre style='margin:0'>AuthorDate: Fri Feb 3 09:32:50 2012 +0100</pre>
 <br>
 <pre style='margin:0'>    a5</pre>
 <pre style='margin:0'>---</pre>

--- a/t/email-content.d/ref-filter
+++ b/t/email-content.d/ref-filter
@@ -87,7 +87,7 @@ in repository test-repo.
 
 commit f0e9a982738fb14c0c66097353bf2404135624fb
 Author: Joe User <user@example.com>
-Date:   Fri Feb 3 09:29:08 2012 +0100
+AuthorDate: Fri Feb 3 09:29:08 2012 +0100
 
     f1
 ---
@@ -135,7 +135,7 @@ in repository test-repo.
 
 commit c742b15e5c9cbb174294c1b3efaa959413bf4137
 Author: Joe User <user@example.com>
-Date:   Fri Feb 3 09:29:13 2012 +0100
+AuthorDate: Fri Feb 3 09:29:13 2012 +0100
 
     f2
 ---
@@ -183,7 +183,7 @@ in repository test-repo.
 
 commit abb8baa7170a6d55bc4311cc819579a929eb0b04
 Author: Joe User <user@example.com>
-Date:   Fri Feb 3 09:31:22 2012 +0100
+AuthorDate: Fri Feb 3 09:31:22 2012 +0100
 
     f3
 ---
@@ -232,7 +232,7 @@ in repository test-repo.
 commit d245c99162aff6fff4879e5d5c17d454766b45db
 Merge: ebf40e1 abb8baa
 Author: Joe User <user@example.com>
-Date:   Fri Feb 3 09:32:27 2012 +0100
+AuthorDate: Fri Feb 3 09:32:27 2012 +0100
 
     m1
 
@@ -281,7 +281,7 @@ in repository test-repo.
 
 commit 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
 Author: Joe User <user@example.com>
-Date:   Fri Feb 3 09:32:50 2012 +0100
+AuthorDate: Fri Feb 3 09:32:50 2012 +0100
 
     a5
 ---
@@ -381,7 +381,7 @@ in repository test-repo.
 commit d245c99162aff6fff4879e5d5c17d454766b45db
 Merge: ebf40e1 abb8baa
 Author: Joe User <user@example.com>
-Date:   Fri Feb 3 09:32:27 2012 +0100
+AuthorDate: Fri Feb 3 09:32:27 2012 +0100
 
     m1
 
@@ -430,7 +430,7 @@ in repository test-repo.
 
 commit 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
 Author: Joe User <user@example.com>
-Date:   Fri Feb 3 09:32:50 2012 +0100
+AuthorDate: Fri Feb 3 09:32:50 2012 +0100
 
     a5
 ---

--- a/t/generate-test-emails
+++ b/t/generate-test-emails
@@ -8,10 +8,10 @@ test_rewind refs/heads/master refs/heads/master^
 test_update refs/heads/release refs/heads/release^^^^
 
 # Should send both summary and revision email:
-test_update refs/heads/release refs/heads/release^
+test_update refs/heads/release refs/heads/release^ -c multimailhook.dateSubstitute='MyDate: '
 # Should send a combined email:
 verbose_do git config multimailhook.refchangelist 'Commit List <commitlist@example.com>'
-test_update refs/heads/release refs/heads/release^
+test_update refs/heads/release refs/heads/release^ -c multimailhook.dateSubstitute=none
 verbose_do git config multimailhook.refchangelist 'Refchange List <refchangelist@example.com>'
 
 test_rewind refs/heads/release refs/heads/release^^ -c multimailhook.refChangeShowGraph=true


### PR DESCRIPTION
I have mixed felling about this change. It does fix a very annoying behavior for me.

Does anyone have a better idea?

The default format was generating text of the form:

moy pushed a commit to branch master
in repository git-multimail.

commit d16ac490b99bca1a88df115af2b1004f76941b2d
Author: Matthieu Moy <Matthieu.Moy@imag.fr>
Date:   Thu Sep 3 18:20:04 2015 +0200

Unfortunately, at least Zimbra Webmail interprets "Date:" as the
beginning of a quoted text, and hides it by default.

While I consider this as a wrong behavior of Zimbra, I have little hope
of getting Zimbra fixed, but we can work around the issue in
git-multimail by not generating "Date:". Short of finding a better name,
this patch uses AuthorDate: (like "git log --format=fuller") instead of
"Date:".