### PR TITLE
Use __del__(), not __del(), in post receive hook.

### DIFF
--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -3469,7 +3469,7 @@ def run_as_post_receive_hook(environment, mailer):
         push = Push(environment, changes)
         push.send_emails(mailer, body_filter=environment.filter_body)
     if hasattr(mailer, '__del__'):
-        mailer.__del()
+        mailer.__del__()
 
 
 def run_as_update_hook(environment, mailer, refname, oldrev, newrev, force_send=False):


### PR DESCRIPTION
(See #144 for prior version, didn't want to force-push an amend.  Will close that momentarily.)

This matches the prior has_attr line, and avoids an issue that looks like:

Traceback (most recent call last):
  File "hooks/post-receive", line 101, in <module>
    git_multimail.run_as_post_receive_hook(environment, mailer)
  File "/data/git/hooks/git-multimail/git-multimail/git_multimail.py", line 3472, in run_as_post_receive_hook
    mailer.__del()
AttributeError: 'SMTPMailer' object has no attribute '__del'

Signed-off-by: Leander Hasty <leander@1stplayable.com>