### PR TITLE
multimail.from: Make the highest priority (i.e. a global override)

### DIFF
--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -803,7 +803,12 @@ class Change(object):
         dictionary."""
 
         values = self.environment.get_values()
-        fromaddr = self.environment.get_fromaddr(change=self)
+
+        # multimailhook.from is a global override, superceding any
+        # environment-specific mechanisms.
+        config = Config('multimailhook')
+        fromaddr = config.get('from') or \
+            self.environment.get_fromaddr(change=self)
         if fromaddr is not None:
             values['fromaddr'] = fromaddr
         values['multimail_version'] = get_version()

--- a/t/email-content.d/all
+++ b/t/email-content.d/all
@@ -1488,6 +1488,7 @@ Administrator <administrator@example.com>.
 EOF
 ######################################################################
 $ git 'config' 'multimailhook.fromCommit' 'author'
+$ git 'config' '--unset' 'multimailhook.from'
 *** Push-update of tracking branch 'refs/remotes/remote'
 ***  - incomplete email generated.
 Sending notification emails to: Refchange List <refchangelist@example.com>
@@ -1500,7 +1501,7 @@ MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: 8bit
 Message-ID: <...>
-From: From <from@example.com>
+From: Joe User <user@example.com>
 Reply-To: pushuser@example.com
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
@@ -1643,7 +1644,7 @@ MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: 8bit
 Message-ID: <...>
-From: From <from@example.com>
+From: Joe User <user@example.com>
 Reply-To: pushuser@example.com
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
@@ -2070,7 +2071,7 @@ MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: 8bit
 Message-ID: <...>
-From: pushuser@example.com
+From: From <from@example.com>
 Reply-To: pushuser@example.com
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
@@ -2109,7 +2110,7 @@ MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: 8bit
 Message-ID: <...>
-From: pushuser@example.com
+From: From <from@example.com>
 Reply-To: pushuser@example.com
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
@@ -2259,7 +2260,7 @@ MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: 8bit
 Message-ID: <...>
-From: pushuser@example.com
+From: From <from@example.com>
 Reply-To: pushuser@example.com
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
@@ -2458,11 +2459,13 @@ Administrator <administrator@example.com>.
 EOF
 ######################################################################
 $ git 'config' '--unset' 'multimailhook.fromRefChange'
+$ git 'config' '--unset' 'multimailhook.from'
 $ git 'config' 'multimailhook.refChangeShowGraph' 'true'
 $ git 'branch' '-D' 'feature'
 Deleted branch feature (was 47ef1f8).
 $ git 'update-ref' '--no-deref' 'HEAD' 'HEAD'
 $ git 'config' 'multimailhook.commitList' ''
+$ git 'config' 'multimailhook.from' 'From <from@example.com>'
 Sending notification emails to: Refchange List <refchangelist@example.com>
 ######################################################################
 /usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF

--- a/t/email-content.t
+++ b/t/email-content.t
@@ -82,7 +82,7 @@ test_email_content 'To/From/Reply-to headers' headers-specific '
 		-c multimailhook.replyToRefChange=reply-to-refchange@example.com \
 		-c multimailhook.fromRefChange=from-refchange@example.com \
 		-c multimailhook.fromCommit=from-commit@example.com \
-		-c multimailhook.from=from-config@example.com
+		-c multimailhook.from=
 '
 
 test_email_content 'emailPrefix' emailprefix '
@@ -233,12 +233,12 @@ test_email_content '' 'test_when_finished "git checkout master && git branch -D 
     'Non-ascii characters in email (test)' accent-python$PYTHON_VERSION '
 	git checkout -b mâstér &&
 	verbose_do test_update refs/heads/mâstér refs/heads/mâstér^ \
-		 -c multimailhook.from=author &&
+		 -c multimailhook.from= &&
 	verbose_do test_update refs/heads/mâstér refs/heads/mâstér^ \
-		-c multimailhook.from=author \
+		-c multimailhook.from= \
 		-c multimailhook.emailMaxLineLength=10 &&
 	verbose_do test_update refs/heads/mâstér refs/heads/mâstér^ \
-		-c multimailhook.from=author \
+		-c multimailhook.from= \
 		-c multimailhook.emailMaxLineLength=10 \
 		-c multimailhook.emailStrictUTF8=false
 '
@@ -252,7 +252,7 @@ test_email_content 'Gerrit environment' gerrit '
 	test_when_finished "git checkout -b master && git branch -d mastèr" &&
 	git checkout -b mastèr && git branch -d master &&
 	echo \$ git_multimail.py --stdout --oldrev refs/heads/mastèr^ --newrev refs/heads/mastèr --refname mastèr --project démo-project --submitter "Sûb Mitter (sub.mitter@example.com)" &&
-	{ "$PYTHON" "$MULTIMAIL" --stdout --oldrev refs/heads/mastèr^ --newrev refs/heads/mastèr --refname mastèr --project démo-project --submitter "Sûb Mitter (sub.mitter@example.com)" >out ; RETCODE=$? ; } &&
+	{ "$PYTHON" "$MULTIMAIL" -c multimailhook.from= --stdout --oldrev refs/heads/mastèr^ --newrev refs/heads/mastèr --refname mastèr --project démo-project --submitter "Sûb Mitter (sub.mitter@example.com)" >out ; RETCODE=$? ; } &&
 	cat out &&
 	test $RETCODE = 0 &&
 	git checkout -b master && git branch -d mastèr &&

--- a/t/generate-test-emails
+++ b/t/generate-test-emails
@@ -26,6 +26,7 @@ test_rewind refs/heads/feature refs/heads/feature^^^
 test_delete refs/heads/feature
 
 verbose_do git config multimailhook.fromCommit author
+verbose_do git config --unset multimailhook.from
 test_create refs/remotes/remote
 test_update refs/remotes/remote refs/heads/master
 verbose_do git config multimailhook.fromRefChange 'From RefChange <from@example.com>'
@@ -44,6 +45,8 @@ verbose_do git config multimailhook.scanCommitForCc true
 test_update refs/heads/formatting refs/heads/formatting^^^
 verbose_do git config --unset multimailhook.fromRefChange
 
+verbose_do git config --unset multimailhook.from
+
 verbose_do git config multimailhook.refChangeShowGraph true
 f=$(git rev-parse feature)
 verbose_do git branch -D feature
@@ -51,6 +54,7 @@ verbose_do git branch -D feature
 # on non-detached HEAD
 verbose_do git update-ref --no-deref HEAD HEAD
 verbose_do git config multimailhook.commitList ''
+verbose_do git config multimailhook.from 'From <from@example.com>'
 test_update refs/heads/master refs/heads/foo
 verbose_do git config multimailhook.refChangeShowGraph false
 git branch feature "$f"


### PR DESCRIPTION
Based on the discussion in #160 , #161 . The commit message once again goes over why it is important to have this option as a global override, which will behave such regardless of any possible future changes to a particular "environment". By popular demand, no get_fromaddr_xxx() is introduced. Instead, override handling is inlined at the existing .get_fromaddr() call site. A work breakdown on this patch was: change code - 5 mins; try to make tests pass - 2 hours. At the end, I was just fuzzing generate-test-emails trying to make minimal changes to expected output. There's still some.

@doanac: FYI.
