### PR TITLE
Split environment-specific mixins into one high-precedence and one low-precedence one

### DIFF
--- a/git-multimail/CHANGES
+++ b/git-multimail/CHANGES
@@ -1,6 +1,13 @@
 Release 1.4.0 (in progress)
 ===========================
 
+* The management of precedence when a setting can be computed in
+  multiple ways has been considerably refactored and modified.
+  multimailhook.from and multimailhook.reponame now have precedence
+  over the environment-specific settings ($GL_REPO/$GL_USER for
+  gitolite, --stash-user/repo for Stash, --submitter/--project for
+  Gerrit).
+
 * Formatting of emails was made slightly more compact, to reduce the
   odds of having long subject lines truncated or wrapped in short list
   of commits.

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -3742,10 +3742,10 @@ def choose_mailer(config, environment):
 
 
 KNOWN_ENVIRONMENTS = {
-    'generic': GenericEnvironmentMixin,
-    'gitolite': GitoliteEnvironmentMixin,
-    'stash': StashEnvironmentMixin,
-    'gerrit': GerritEnvironmentMixin,
+    'generic': {'mixin': GenericEnvironmentMixin},
+    'gitolite': {'mixin': GitoliteEnvironmentMixin},
+    'stash': {'mixin': StashEnvironmentMixin},
+    'gerrit': {'mixin': GerritEnvironmentMixin},
     }
 
 
@@ -3779,7 +3779,7 @@ def choose_environment(config, osenv=None, env=None, recipients=None,
         else:
             env = 'generic'
 
-    environment_mixins.insert(0, KNOWN_ENVIRONMENTS[env])
+    environment_mixins.insert(0, KNOWN_ENVIRONMENTS[env]['mixin'])
 
     if env == 'stash':
         environment_kw['user'] = hook_info['stash_user']

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -3198,12 +3198,10 @@ class IncrementalDateTime(object):
 
 class StashEnvironmentHighPrecMixin(Environment):
     def __init__(self, user=None, repo=None, **kw):
-        super(StashEnvironmentHighPrecMixin, self).__init__(user=user, **kw)
+        super(StashEnvironmentHighPrecMixin,
+              self).__init__(user=user, repo=repo, **kw)
         self.__user = user
         self.__repo = repo
-
-    def get_repo_shortname(self):
-        return self.__repo
 
     def get_pusher(self):
         return re.match('(.*?)\s*<', self.__user).group(1)
@@ -3213,9 +3211,13 @@ class StashEnvironmentHighPrecMixin(Environment):
 
 
 class StashEnvironmentLowPrecMixin(Environment):
-    def __init__(self, user=None, **kw):
+    def __init__(self, user=None, repo=None, **kw):
         super(StashEnvironmentLowPrecMixin, self).__init__(**kw)
+        self.__repo = repo
         self.__user = user
+
+    def get_repo_shortname(self):
+        return self.__repo
 
     def get_fromaddr(self, change=None):
         return self.__user
@@ -3224,7 +3226,7 @@ class StashEnvironmentLowPrecMixin(Environment):
 class GerritEnvironmentHighPrecMixin(Environment):
     def __init__(self, project=None, submitter=None, update_method=None, **kw):
         super(GerritEnvironmentHighPrecMixin,
-              self).__init__(submitter=submitter, **kw)
+              self).__init__(submitter=submitter, project=project, **kw)
         self.__project = project
         self.__submitter = submitter
         self.__update_method = update_method
@@ -3279,8 +3281,9 @@ class GerritEnvironmentHighPrecMixin(Environment):
 
 
 class GerritEnvironmentLowPrecMixin(Environment):
-    def __init__(self, submitter=None, **kw):
+    def __init__(self, project=None, submitter=None, **kw):
         super(GerritEnvironmentLowPrecMixin, self).__init__(**kw)
+        self.__project = project
         self.__submitter = submitter
 
     def get_fromaddr(self, change=None):

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -2935,6 +2935,33 @@ class StaticRecipientsEnvironmentMixin(Environment):
         return self.__revision_recipients
 
 
+class CLIRecipientsEnvironmentMixin(Environment):
+    """Mixin storing recipients information comming from the
+    command-line."""
+
+    def __init__(self, cli_recipients=None, **kw):
+        super(CLIRecipientsEnvironmentMixin, self).__init__(**kw)
+        self.__cli_recipients = cli_recipients
+
+    def get_refchange_recipients(self, refchange):
+        if self.__cli_recipients is None:
+            return super(CLIRecipientsEnvironmentMixin,
+                         self).get_refchange_recipients(refchange)
+        return self.__cli_recipients
+
+    def get_announce_recipients(self, annotated_tag_change):
+        if self.__cli_recipients is None:
+            return super(CLIRecipientsEnvironmentMixin,
+                         self).get_announce_recipients(annotated_tag_change)
+        return self.__cli_recipients
+
+    def get_revision_recipients(self, revision):
+        if self.__cli_recipients is None:
+            return super(CLIRecipientsEnvironmentMixin,
+                         self).get_revision_recipients(revision)
+        return self.__cli_recipients
+
+
 class ConfigRecipientsEnvironmentMixin(
         ConfigEnvironmentMixin,
         StaticRecipientsEnvironmentMixin
@@ -3728,6 +3755,8 @@ def choose_environment(config, osenv=None, env=None, recipients=None,
         osenv = os.environ
 
     environment_mixins = [
+        ConfigRecipientsEnvironmentMixin,
+        CLIRecipientsEnvironmentMixin,
         ConfigRefFilterEnvironmentMixin,
         ProjectdescEnvironmentMixin,
         ConfigMaxlinesEnvironmentMixin,
@@ -3760,14 +3789,7 @@ def choose_environment(config, osenv=None, env=None, recipients=None,
         environment_kw['submitter'] = hook_info['submitter']
         environment_kw['update_method'] = hook_info['update_method']
 
-    if recipients:
-        environment_mixins.insert(0, StaticRecipientsEnvironmentMixin)
-        environment_kw['refchange_recipients'] = recipients
-        environment_kw['announce_recipients'] = recipients
-        environment_kw['revision_recipients'] = recipients
-        environment_kw['scancommitforcc'] = config.get('scancommitforcc')
-    else:
-        environment_mixins.insert(0, ConfigRecipientsEnvironmentMixin)
+    environment_kw['cli_recipients'] = recipients
 
     environment_klass = type(
         'EffectiveEnvironment',

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -3233,9 +3233,6 @@ class GerritEnvironmentHighPrecMixin(Environment):
         "Make an 'update_method' value available for templates."
         self.COMPUTED_KEYS += ['update_method']
 
-    def get_repo_shortname(self):
-        return self.__project
-
     def get_pusher(self):
         if self.__submitter:
             if self.__submitter.find('<') != -1:
@@ -3285,6 +3282,9 @@ class GerritEnvironmentLowPrecMixin(Environment):
         super(GerritEnvironmentLowPrecMixin, self).__init__(**kw)
         self.__project = project
         self.__submitter = submitter
+
+    def get_repo_shortname(self):
+        return self.__project
 
     def get_fromaddr(self, change=None):
         if self.__submitter and self.__submitter.find('<') != -1:

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -2911,12 +2911,21 @@ class StaticRecipientsEnvironmentMixin(Environment):
         self.__revision_recipients = revision_recipients
 
     def get_refchange_recipients(self, refchange):
+        if self.__refchange_recipients is None:
+            return super(StaticRecipientsEnvironmentMixin,
+                         self).get_refchange_recipients(refchange)
         return self.__refchange_recipients
 
     def get_announce_recipients(self, annotated_tag_change):
+        if self.__announce_recipients is None:
+            return super(StaticRecipientsEnvironmentMixin,
+                         self).get_refchange_recipients(annotated_tag_change)
         return self.__announce_recipients
 
     def get_revision_recipients(self, revision):
+        if self.__revision_recipients is None:
+            return super(StaticRecipientsEnvironmentMixin,
+                         self).get_refchange_recipients(revision)
         return self.__revision_recipients
 
 

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -3123,21 +3123,6 @@ class GenericEnvironmentMixin(Environment):
         return self.osenv.get('USER', self.osenv.get('USERNAME', 'unknown user'))
 
 
-class GenericEnvironment(
-        ProjectdescEnvironmentMixin,
-        ConfigMaxlinesEnvironmentMixin,
-        ComputeFQDNEnvironmentMixin,
-        ConfigFilterLinesEnvironmentMixin,
-        ConfigRecipientsEnvironmentMixin,
-        ConfigRefFilterEnvironmentMixin,
-        PusherDomainEnvironmentMixin,
-        ConfigOptionsEnvironmentMixin,
-        GenericEnvironmentMixin,
-        Environment,
-        ):
-    pass
-
-
 class GitoliteEnvironmentHighPrecMixin(Environment):
     def get_pusher(self):
         return self.osenv.get('GL_USER', 'unknown user')
@@ -3211,22 +3196,6 @@ class IncrementalDateTime(object):
         return formatted
 
 
-class GitoliteEnvironment(
-        GitoliteEnvironmentHighPrecMixin,
-        ProjectdescEnvironmentMixin,
-        ConfigMaxlinesEnvironmentMixin,
-        ComputeFQDNEnvironmentMixin,
-        ConfigFilterLinesEnvironmentMixin,
-        ConfigRecipientsEnvironmentMixin,
-        ConfigRefFilterEnvironmentMixin,
-        PusherDomainEnvironmentMixin,
-        ConfigOptionsEnvironmentMixin,
-        GitoliteEnvironmentLowPrecMixin,
-        Environment,
-        ):
-    pass
-
-
 class StashEnvironmentMixin(Environment):
     def __init__(self, user=None, repo=None, **kw):
         super(StashEnvironmentMixin, self).__init__(**kw)
@@ -3244,21 +3213,6 @@ class StashEnvironmentMixin(Environment):
 
     def get_fromaddr(self, change=None):
         return self.__user
-
-
-class StashEnvironment(
-        StashEnvironmentMixin,
-        ProjectdescEnvironmentMixin,
-        ConfigMaxlinesEnvironmentMixin,
-        ComputeFQDNEnvironmentMixin,
-        ConfigFilterLinesEnvironmentMixin,
-        ConfigRecipientsEnvironmentMixin,
-        ConfigRefFilterEnvironmentMixin,
-        PusherDomainEnvironmentMixin,
-        ConfigOptionsEnvironmentMixin,
-        Environment,
-        ):
-    pass
 
 
 class GerritEnvironmentHighPrecMixin(Environment):
@@ -3321,21 +3275,6 @@ class GerritEnvironmentHighPrecMixin(Environment):
 
     def get_update_method(self):
         return self.__update_method
-
-
-class GerritEnvironment(
-        GerritEnvironmentHighPrecMixin,
-        ProjectdescEnvironmentMixin,
-        ConfigMaxlinesEnvironmentMixin,
-        ComputeFQDNEnvironmentMixin,
-        ConfigFilterLinesEnvironmentMixin,
-        ConfigRecipientsEnvironmentMixin,
-        ConfigRefFilterEnvironmentMixin,
-        PusherDomainEnvironmentMixin,
-        ConfigOptionsEnvironmentMixin,
-        Environment,
-        ):
-    pass
 
 
 class GerritEnvironmentLowPrecMixin(Environment):
@@ -3818,6 +3757,12 @@ def build_environment_klass(env_name):
         )
     KNOWN_ENVIRONMENTS[env_name]['class'] = environment_klass
     return environment_klass
+
+
+GerritEnvironment = build_environment_klass('gerrit')
+StashEnvironment = build_environment_klass('stash')
+GitoliteEnvironment = build_environment_klass('gitolite')
+GenericEnvironment = build_environment_klass('generic')
 
 
 def build_environment(environment_klass, env, config,

--- a/t/email-content.d/gerrit
+++ b/t/email-content.d/gerrit
@@ -13,7 +13,7 @@ Message-ID: <...>
 From: From <from@example.com>
 Reply-To: =?utf-8?q?S=C3=BBb_Mitter?= <sub.mitter@example.com>
 X-Git-Host: fqdn.example.org
-X-Git-Repo: =?utf-8?q?d=C3=A9mo-project?=
+X-Git-Repo: test-repo
 X-Git-Refname: =?utf-8?q?refs/heads/mast=C3=A8r?=
 X-Git-Reftype: branch
 X-Git-Oldrev: d245c99162aff6fff4879e5d5c17d454766b45db
@@ -25,7 +25,7 @@ Auto-Submitted: auto-generated
 This is an automated email from the git hooks/post-receive script.
 
 Sûb Mitter pushed a change to branch mastèr
-in repository démo-project.
+in repository test-repo.
 
     from d245c99  m1
      new 902dfe1  a5
@@ -56,7 +56,7 @@ Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
 X-Git-Host: fqdn.example.org
-X-Git-Repo: =?utf-8?q?d=C3=A9mo-project?=
+X-Git-Repo: test-repo
 X-Git-Refname: =?utf-8?q?refs/heads/mast=C3=A8r?=
 X-Git-Reftype: branch
 X-Git-Rev: 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
@@ -67,7 +67,7 @@ Auto-Submitted: auto-generated
 This is an automated email from the git hooks/post-receive script.
 
 Sûb Mitter pushed a commit to branch mastèr
-in repository démo-project.
+in repository test-repo.
 
 commit 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
 Author: Joe User <user@example.com>
@@ -195,7 +195,7 @@ Message-ID: <...>
 From: Joe User <user@example.com>
 Reply-To: Submitter
 X-Git-Host: fqdn.example.org
-X-Git-Repo: demo-project
+X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
 X-Git-Reftype: branch
 X-Git-Oldrev: d245c99162aff6fff4879e5d5c17d454766b45db
@@ -207,7 +207,7 @@ Auto-Submitted: auto-generated
 This is an automated email from the git hooks/post-receive script.
 
 Submitter without Email pushed a change to branch master
-in repository demo-project.
+in repository test-repo.
 
     from d245c99  m1
      new 902dfe1  a5
@@ -238,7 +238,7 @@ Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
 X-Git-Host: fqdn.example.org
-X-Git-Repo: demo-project
+X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
 X-Git-Reftype: branch
 X-Git-Rev: 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
@@ -249,7 +249,7 @@ Auto-Submitted: auto-generated
 This is an automated email from the git hooks/post-receive script.
 
 Submitter without Email pushed a commit to branch master
-in repository demo-project.
+in repository test-repo.
 
 commit 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
 Author: Joe User <user@example.com>

--- a/t/email-content.d/gerrit
+++ b/t/email-content.d/gerrit
@@ -92,7 +92,7 @@ Administrator <administrator@example.com>.
 ===========================================================================
 Switched to a new branch 'master'
 Deleted branch mastèr (was 902dfe1).
-$ git_multimail.py --stdout --oldrev refs/heads/master^ --newrev refs/heads/master --refname master --project demo-project --submitter Sub Mîtter (sub.mitter@example.com)
+$ git_multimail.py -c multimailhook.from= --stdout --oldrev refs/heads/master^ --newrev refs/heads/master --refname master --project demo-project --submitter Sub Mîtter (sub.mitter@example.com)
 Sending notification emails to: Refchange List <refchangelist@example.com>
 ===========================================================================
 Date: ...
@@ -182,7 +182,7 @@ index 63a911f..7ed6ff8 100644
 To stop receiving notification emails like this one, please contact
 Administrator <administrator@example.com>.
 ===========================================================================
-$ git_multimail.py --stdout --oldrev refs/heads/master^ --newrev refs/heads/master --refname master --project demo-project --submitter Submitter without Email
+$ git_multimail.py -c multimailhook.from= --stdout --oldrev refs/heads/master^ --newrev refs/heads/master --refname master --project demo-project --submitter Submitter without Email
 Sending notification emails to: Refchange List <refchangelist@example.com>
 ===========================================================================
 Date: ...
@@ -192,7 +192,7 @@ MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: 8bit
 Message-ID: <...>
-From: From <from@example.com>
+From: Joe User <user@example.com>
 Reply-To: Submitter
 X-Git-Host: fqdn.example.org
 X-Git-Repo: demo-project
@@ -233,7 +233,7 @@ Subject: *test-repo* 01/01: a5
 MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: 8bit
-From: From <from@example.com>
+From: Joe User <user@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>

--- a/t/email-content.d/gerrit
+++ b/t/email-content.d/gerrit
@@ -92,6 +92,96 @@ Administrator <administrator@example.com>.
 ===========================================================================
 Switched to a new branch 'master'
 Deleted branch mastèr (was 902dfe1).
+$ git_multimail.py --stdout --oldrev refs/heads/master^ --newrev refs/heads/master --refname master --project demo-project --submitter Sub Mîtter (sub.mitter@example.com)
+Sending notification emails to: Refchange List <refchangelist@example.com>
+===========================================================================
+Date: ...
+To: Refchange List <refchangelist@example.com>
+Subject: *test-repo* branch master updated (d245c99 -> 902dfe1)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+Message-ID: <...>
+From: =?utf-8?q?Sub_M=C3=AEtter?= <sub.mitter@example.com>
+Reply-To: =?utf-8?q?Sub_M=C3=AEtter?= <sub.mitter@example.com>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: demo-project
+X-Git-Refname: refs/heads/master
+X-Git-Reftype: branch
+X-Git-Oldrev: d245c99162aff6fff4879e5d5c17d454766b45db
+X-Git-Newrev: 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
+X-Git-NotificationType: ref_changed
+X-Git-Multimail-Version: ...
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+Sub Mîtter pushed a change to branch master
+in repository demo-project.
+
+    from d245c99  m1
+     new 902dfe1  a5
+
+The 1 revisions listed above as "new" are entirely new to this
+repository and will be described in separate emails.  The revisions
+listed as "add" were already present in the repository and have only
+been added to this reference.
+
+
+Summary of changes:
+ a.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+===========================================================================
+===========================================================================
+Date: ...
+To: Commit List <commitlist@example.com>
+Subject: *test-repo* 01/01: a5
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+From: =?utf-8?q?Sub_M=C3=AEtter?= <sub.mitter@example.com>
+Reply-To: Joe User <user@example.com>
+In-Reply-To: <...>
+References: <...>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: demo-project
+X-Git-Refname: refs/heads/master
+X-Git-Reftype: branch
+X-Git-Rev: 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
+X-Git-NotificationType: diff
+X-Git-Multimail-Version: ...
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+Sub Mîtter pushed a commit to branch master
+in repository demo-project.
+
+commit 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
+Author: Joe User <user@example.com>
+AuthorDate: Fri Feb 3 09:32:50 2012 +0100
+
+    a5
+---
+ a.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/a.txt b/a.txt
+index 63a911f..7ed6ff8 100644
+--- a/a.txt
++++ b/a.txt
+@@ -1 +1 @@
+-m1
++5
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+===========================================================================
 $ git_multimail.py --stdout --oldrev refs/heads/master^ --newrev refs/heads/master --refname master --project demo-project --submitter Submitter without Email
 Sending notification emails to: Refchange List <refchangelist@example.com>
 ===========================================================================

--- a/t/email-content.d/gerrit
+++ b/t/email-content.d/gerrit
@@ -10,7 +10,7 @@ MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: 8bit
 Message-ID: <...>
-From: =?utf-8?q?S=C3=BBb_Mitter?= <sub.mitter@example.com>
+From: From <from@example.com>
 Reply-To: =?utf-8?q?S=C3=BBb_Mitter?= <sub.mitter@example.com>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: =?utf-8?q?d=C3=A9mo-project?=
@@ -51,7 +51,7 @@ Subject: *test-repo* 01/01: a5
 MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: 8bit
-From: =?utf-8?q?S=C3=BBb_Mitter?= <sub.mitter@example.com>
+From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>

--- a/t/email-content.d/gerrit
+++ b/t/email-content.d/gerrit
@@ -92,7 +92,7 @@ Administrator <administrator@example.com>.
 ===========================================================================
 Switched to a new branch 'master'
 Deleted branch mastèr (was 902dfe1).
-$ git_multimail.py -c multimailhook.from= --stdout --oldrev refs/heads/master^ --newrev refs/heads/master --refname master --project demo-project --submitter Sub Mîtter (sub.mitter@example.com)
+$ git_multimail.py -c multimailhook.from= -c multimailhook.reponame= --stdout --oldrev refs/heads/master^ --newrev refs/heads/master --refname master --project demo-project --submitter Sub Mîtter (sub.mitter@example.com)
 Sending notification emails to: Refchange List <refchangelist@example.com>
 ===========================================================================
 Date: ...

--- a/t/email-content.d/stash
+++ b/t/email-content.d/stash
@@ -8,7 +8,7 @@ MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: 8bit
 Message-ID: <...>
-From: =?utf-8?q?Stash_S=C3=BBb_Mitter?= <sub.mitter@example.com>
+From: From <from@example.com>
 Reply-To: =?utf-8?q?Stash_S=C3=BBb_Mitter?= <sub.mitter@example.com>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: =?utf-8?q?d=C3=A9mo-project?=
@@ -49,7 +49,7 @@ Subject: *test-repo* 01/01: a5
 MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: 8bit
-From: =?utf-8?q?Stash_S=C3=BBb_Mitter?= <sub.mitter@example.com>
+From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>

--- a/t/email-content.d/stash
+++ b/t/email-content.d/stash
@@ -1,0 +1,180 @@
+$ git_multimail.py --stdout refs/heads/master refs/heads/master^ refs/heads/master --stash-repo démo-project --stash-user Stash Sûb Mitter <sub.mitter@example.com>
+Sending notification emails to: Refchange List <refchangelist@example.com>
+===========================================================================
+Date: ...
+To: Refchange List <refchangelist@example.com>
+Subject: *test-repo* branch master updated (d245c99 -> 902dfe1)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+Message-ID: <...>
+From: =?utf-8?q?Stash_S=C3=BBb_Mitter?= <sub.mitter@example.com>
+Reply-To: =?utf-8?q?Stash_S=C3=BBb_Mitter?= <sub.mitter@example.com>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: =?utf-8?q?d=C3=A9mo-project?=
+X-Git-Refname: refs/heads/master
+X-Git-Reftype: branch
+X-Git-Oldrev: d245c99162aff6fff4879e5d5c17d454766b45db
+X-Git-Newrev: 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
+X-Git-NotificationType: ref_changed
+X-Git-Multimail-Version: ...
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+Stash Sûb Mitter pushed a change to branch master
+in repository démo-project.
+
+    from d245c99  m1
+     new 902dfe1  a5
+
+The 1 revisions listed above as "new" are entirely new to this
+repository and will be described in separate emails.  The revisions
+listed as "add" were already present in the repository and have only
+been added to this reference.
+
+
+Summary of changes:
+ a.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+===========================================================================
+===========================================================================
+Date: ...
+To: Commit List <commitlist@example.com>
+Subject: *test-repo* 01/01: a5
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+From: =?utf-8?q?Stash_S=C3=BBb_Mitter?= <sub.mitter@example.com>
+Reply-To: Joe User <user@example.com>
+In-Reply-To: <...>
+References: <...>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: =?utf-8?q?d=C3=A9mo-project?=
+X-Git-Refname: refs/heads/master
+X-Git-Reftype: branch
+X-Git-Rev: 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
+X-Git-NotificationType: diff
+X-Git-Multimail-Version: ...
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+Stash Sûb Mitter pushed a commit to branch master
+in repository démo-project.
+
+commit 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
+Author: Joe User <user@example.com>
+AuthorDate: Fri Feb 3 09:32:50 2012 +0100
+
+    a5
+---
+ a.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/a.txt b/a.txt
+index 63a911f..7ed6ff8 100644
+--- a/a.txt
++++ b/a.txt
+@@ -1 +1 @@
+-m1
++5
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+===========================================================================
+$ git_multimail.py -c multimailhook.from= --stdout refs/heads/master refs/heads/master^ refs/heads/master --stash-repo stash-démo-project --stash-user Stash Sub Mîtter <sub.mitter@example.com>
+Sending notification emails to: Refchange List <refchangelist@example.com>
+===========================================================================
+Date: ...
+To: Refchange List <refchangelist@example.com>
+Subject: *test-repo* branch master updated (d245c99 -> 902dfe1)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+Message-ID: <...>
+From: =?utf-8?q?Stash_Sub_M=C3=AEtter?= <sub.mitter@example.com>
+Reply-To: =?utf-8?q?Stash_Sub_M=C3=AEtter?= <sub.mitter@example.com>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: =?utf-8?q?stash-d=C3=A9mo-project?=
+X-Git-Refname: refs/heads/master
+X-Git-Reftype: branch
+X-Git-Oldrev: d245c99162aff6fff4879e5d5c17d454766b45db
+X-Git-Newrev: 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
+X-Git-NotificationType: ref_changed
+X-Git-Multimail-Version: ...
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+Stash Sub Mîtter pushed a change to branch master
+in repository stash-démo-project.
+
+    from d245c99  m1
+     new 902dfe1  a5
+
+The 1 revisions listed above as "new" are entirely new to this
+repository and will be described in separate emails.  The revisions
+listed as "add" were already present in the repository and have only
+been added to this reference.
+
+
+Summary of changes:
+ a.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+===========================================================================
+===========================================================================
+Date: ...
+To: Commit List <commitlist@example.com>
+Subject: *test-repo* 01/01: a5
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+From: =?utf-8?q?Stash_Sub_M=C3=AEtter?= <sub.mitter@example.com>
+Reply-To: Joe User <user@example.com>
+In-Reply-To: <...>
+References: <...>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: =?utf-8?q?stash-d=C3=A9mo-project?=
+X-Git-Refname: refs/heads/master
+X-Git-Reftype: branch
+X-Git-Rev: 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
+X-Git-NotificationType: diff
+X-Git-Multimail-Version: ...
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+Stash Sub Mîtter pushed a commit to branch master
+in repository stash-démo-project.
+
+commit 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
+Author: Joe User <user@example.com>
+AuthorDate: Fri Feb 3 09:32:50 2012 +0100
+
+    a5
+---
+ a.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/a.txt b/a.txt
+index 63a911f..7ed6ff8 100644
+--- a/a.txt
++++ b/a.txt
+@@ -1 +1 @@
+-m1
++5
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+===========================================================================

--- a/t/email-content.d/stash
+++ b/t/email-content.d/stash
@@ -11,7 +11,7 @@ Message-ID: <...>
 From: From <from@example.com>
 Reply-To: =?utf-8?q?Stash_S=C3=BBb_Mitter?= <sub.mitter@example.com>
 X-Git-Host: fqdn.example.org
-X-Git-Repo: =?utf-8?q?d=C3=A9mo-project?=
+X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
 X-Git-Reftype: branch
 X-Git-Oldrev: d245c99162aff6fff4879e5d5c17d454766b45db
@@ -23,7 +23,7 @@ Auto-Submitted: auto-generated
 This is an automated email from the git hooks/post-receive script.
 
 Stash Sûb Mitter pushed a change to branch master
-in repository démo-project.
+in repository test-repo.
 
     from d245c99  m1
      new 902dfe1  a5
@@ -54,7 +54,7 @@ Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
 X-Git-Host: fqdn.example.org
-X-Git-Repo: =?utf-8?q?d=C3=A9mo-project?=
+X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
 X-Git-Reftype: branch
 X-Git-Rev: 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
@@ -65,7 +65,7 @@ Auto-Submitted: auto-generated
 This is an automated email from the git hooks/post-receive script.
 
 Stash Sûb Mitter pushed a commit to branch master
-in repository démo-project.
+in repository test-repo.
 
 commit 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
 Author: Joe User <user@example.com>

--- a/t/email-content.d/stash
+++ b/t/email-content.d/stash
@@ -88,7 +88,7 @@ index 63a911f..7ed6ff8 100644
 To stop receiving notification emails like this one, please contact
 Administrator <administrator@example.com>.
 ===========================================================================
-$ git_multimail.py -c multimailhook.from= --stdout refs/heads/master refs/heads/master^ refs/heads/master --stash-repo stash-démo-project --stash-user Stash Sub Mîtter <sub.mitter@example.com>
+$ git_multimail.py -c multimailhook.from= -c multimailhook.reponame= --stdout refs/heads/master refs/heads/master^ refs/heads/master --stash-repo stash-démo-project --stash-user Stash Sub Mîtter <sub.mitter@example.com>
 Sending notification emails to: Refchange List <refchangelist@example.com>
 ===========================================================================
 Date: ...

--- a/t/email-content.t
+++ b/t/email-content.t
@@ -256,6 +256,11 @@ test_email_content 'Gerrit environment' gerrit '
 	cat out &&
 	test $RETCODE = 0 &&
 	git checkout -b master && git branch -d mastèr &&
+	echo \$ git_multimail.py --stdout --oldrev refs/heads/master^ --newrev refs/heads/master --refname master --project demo-project --submitter "Sub Mîtter (sub.mitter@example.com)" &&
+	{ "$PYTHON" "$MULTIMAIL" --stdout --oldrev refs/heads/master^ --newrev refs/heads/master --refname master --project demo-project --submitter "Sub Mîtter (sub.mitter@example.com)" >out ; RETCODE=$? ; } &&
+	RETCODE=$? &&
+	cat out &&
+	test $RETCODE = 0 &&
 	echo \$ git_multimail.py --stdout --oldrev refs/heads/master^ --newrev refs/heads/master --refname master --project demo-project --submitter "Submitter without Email" &&
 	{ "$PYTHON" "$MULTIMAIL" --stdout --oldrev refs/heads/master^ --newrev refs/heads/master --refname master --project demo-project --submitter "Submitter without Email" >out ; RETCODE=$? ; } &&
 	RETCODE=$? &&

--- a/t/email-content.t
+++ b/t/email-content.t
@@ -256,8 +256,8 @@ test_email_content 'Gerrit environment' gerrit '
 	cat out &&
 	test $RETCODE = 0 &&
 	git checkout -b master && git branch -d mastèr &&
-	echo \$ git_multimail.py -c multimailhook.from= --stdout --oldrev refs/heads/master^ --newrev refs/heads/master --refname master --project demo-project --submitter "Sub Mîtter (sub.mitter@example.com)" &&
-	{ "$PYTHON" "$MULTIMAIL" -c multimailhook.from= --stdout --oldrev refs/heads/master^ --newrev refs/heads/master --refname master --project demo-project --submitter "Sub Mîtter (sub.mitter@example.com)" >out ; RETCODE=$? ; } &&
+	echo \$ git_multimail.py -c multimailhook.from= -c multimailhook.reponame= --stdout --oldrev refs/heads/master^ --newrev refs/heads/master --refname master --project demo-project --submitter "Sub Mîtter (sub.mitter@example.com)" &&
+	{ "$PYTHON" "$MULTIMAIL" -c multimailhook.from= -c multimailhook.reponame= --stdout --oldrev refs/heads/master^ --newrev refs/heads/master --refname master --project demo-project --submitter "Sub Mîtter (sub.mitter@example.com)" >out ; RETCODE=$? ; } &&
 	RETCODE=$? &&
 	cat out &&
 	test $RETCODE = 0 &&
@@ -274,8 +274,8 @@ test_email_content 'Stash environment' stash '
 	{ "$PYTHON" "$MULTIMAIL" --stdout refs/heads/master refs/heads/master^ refs/heads/master --stash-repo démo-project --stash-user "Stash Sûb Mitter <sub.mitter@example.com>" >out ; RETCODE=$? ; } &&
 	cat out &&
 	test $RETCODE = 0 &&
-	echo \$ git_multimail.py -c multimailhook.from= --stdout refs/heads/master refs/heads/master^ refs/heads/master --stash-repo stash-démo-project --stash-user "Stash Sub Mîtter <sub.mitter@example.com>" &&
-	{ "$PYTHON" "$MULTIMAIL" -c multimailhook.from= --stdout refs/heads/master refs/heads/master^ refs/heads/master --stash-repo stash-démo-project --stash-user "Stash Sub Mîtter <sub.mitter@example.com>" >out ; RETCODE=$? ; } &&
+	echo \$ git_multimail.py -c multimailhook.from= -c multimailhook.reponame= --stdout refs/heads/master refs/heads/master^ refs/heads/master --stash-repo stash-démo-project --stash-user "Stash Sub Mîtter <sub.mitter@example.com>" &&
+	{ "$PYTHON" "$MULTIMAIL" -c multimailhook.from= -c multimailhook.reponame= --stdout refs/heads/master refs/heads/master^ refs/heads/master --stash-repo stash-démo-project --stash-user "Stash Sub Mîtter <sub.mitter@example.com>" >out ; RETCODE=$? ; } &&
 	RETCODE=$? &&
 	cat out &&
 	test $RETCODE = 0

--- a/t/email-content.t
+++ b/t/email-content.t
@@ -256,13 +256,13 @@ test_email_content 'Gerrit environment' gerrit '
 	cat out &&
 	test $RETCODE = 0 &&
 	git checkout -b master && git branch -d mastèr &&
-	echo \$ git_multimail.py --stdout --oldrev refs/heads/master^ --newrev refs/heads/master --refname master --project demo-project --submitter "Sub Mîtter (sub.mitter@example.com)" &&
-	{ "$PYTHON" "$MULTIMAIL" --stdout --oldrev refs/heads/master^ --newrev refs/heads/master --refname master --project demo-project --submitter "Sub Mîtter (sub.mitter@example.com)" >out ; RETCODE=$? ; } &&
+	echo \$ git_multimail.py -c multimailhook.from= --stdout --oldrev refs/heads/master^ --newrev refs/heads/master --refname master --project demo-project --submitter "Sub Mîtter (sub.mitter@example.com)" &&
+	{ "$PYTHON" "$MULTIMAIL" -c multimailhook.from= --stdout --oldrev refs/heads/master^ --newrev refs/heads/master --refname master --project demo-project --submitter "Sub Mîtter (sub.mitter@example.com)" >out ; RETCODE=$? ; } &&
 	RETCODE=$? &&
 	cat out &&
 	test $RETCODE = 0 &&
-	echo \$ git_multimail.py --stdout --oldrev refs/heads/master^ --newrev refs/heads/master --refname master --project demo-project --submitter "Submitter without Email" &&
-	{ "$PYTHON" "$MULTIMAIL" --stdout --oldrev refs/heads/master^ --newrev refs/heads/master --refname master --project demo-project --submitter "Submitter without Email" >out ; RETCODE=$? ; } &&
+	echo \$ git_multimail.py -c multimailhook.from= --stdout --oldrev refs/heads/master^ --newrev refs/heads/master --refname master --project demo-project --submitter "Submitter without Email" &&
+	{ "$PYTHON" "$MULTIMAIL" -c multimailhook.from= --stdout --oldrev refs/heads/master^ --newrev refs/heads/master --refname master --project demo-project --submitter "Submitter without Email" >out ; RETCODE=$? ; } &&
 	RETCODE=$? &&
 	cat out &&
 	test $RETCODE = 0

--- a/t/email-content.t
+++ b/t/email-content.t
@@ -263,6 +263,19 @@ test_email_content 'Gerrit environment' gerrit '
 	test $RETCODE = 0
 '
 
+test_email_content 'Stash environment' stash '
+	# (no verbose_do since "$MULTIMAIL" changes from a machine to another)
+	echo \$ git_multimail.py --stdout refs/heads/master refs/heads/master^ refs/heads/master --stash-repo démo-project --stash-user "Stash Sûb Mitter <sub.mitter@example.com>" &&
+	{ "$PYTHON" "$MULTIMAIL" --stdout refs/heads/master refs/heads/master^ refs/heads/master --stash-repo démo-project --stash-user "Stash Sûb Mitter <sub.mitter@example.com>" >out ; RETCODE=$? ; } &&
+	cat out &&
+	test $RETCODE = 0 &&
+	echo \$ git_multimail.py -c multimailhook.from= --stdout refs/heads/master refs/heads/master^ refs/heads/master --stash-repo stash-démo-project --stash-user "Stash Sub Mîtter <sub.mitter@example.com>" &&
+	{ "$PYTHON" "$MULTIMAIL" -c multimailhook.from= --stdout refs/heads/master refs/heads/master^ refs/heads/master --stash-repo stash-démo-project --stash-user "Stash Sub Mîtter <sub.mitter@example.com>" >out ; RETCODE=$? ; } &&
+	RETCODE=$? &&
+	cat out &&
+	test $RETCODE = 0
+'
+
 # The old test infrastructure was using one big 'generate-test-emails'
 # script. Existing tests are kept there, but new tests should be added
 # with separate test_expect_success.

--- a/t/test-cli.t
+++ b/t/test-cli.t
@@ -51,4 +51,9 @@ test_expect_success '--force-send does consider everything new' '
 	test $(grep -c Subject out) -eq 3
 '
 
+test_expect_success 'error if no recipient is configured' '
+	test_must_fail $MULTIMAIL --stdout refs/heads/master master^^ master 2>err &&
+	grep "No email recipients configured" err
+'
+
 test_done


### PR DESCRIPTION
The precedence of environment-specific and common mixins were not clear: in `choose_environment` we inserted the environment-specific mixin at the head of the list, while the static `*Environment` classes were build with the environment-specific mixin at the last but one position. This was issue #163.

As a result, test-env, which used for example `GitoliteEnvironment` was testing that `$GL_REPO` had lower precedence than the config file, but this wasn't true for normal use of `git_multimail.py`.

Actually, the right precedence order depends on the variable. For example, the from address should be computed with `multimailhook.from` having the highest precedence (issue #160), but we just saw that `$GL_REPO` should have low precedence.

This branch fixes both issues by:

* Computing `*Environment` classes dynamically, and use the same codepath for them and for `choose_environment`.

* Split environment-specific mixins into one high-precedence and a low-precedence one. This allows each environment to choose the level of precedence of each variable.

It should be ready for merge (I'll probably do so within the next few days), but comments are obviously welcome (@pfalcon, @doanac : can you test in your use-case?).