### PR TITLE
Subject max length

### DIFF
--- a/git-multimail/CHANGES
+++ b/git-multimail/CHANGES
@@ -28,6 +28,9 @@ Formatting emails
 * multimailhook.emailPrefix may now use the '%(repo_shortname)s'
   placeholder for the repository's short name.
 
+* A new option multimailhook.subjectMaxLength is available to truncate
+  overly long subject lines.
+
 Bug fixes and minor changes
 ---------------------------
 

--- a/git-multimail/README
+++ b/git-multimail/README
@@ -466,6 +466,17 @@ multimailhook.emailMaxLineLength
     lines, the diffs are probably unreadable anyway.  To disable line
     truncation, set this option to 0.
 
+multimailhook.subjectMaxLength
+    The maximum length of the subject line (i.e. the ``oneline`` field
+    in templates, not including the prefix). Lines longer than this
+    limit are truncated to this length with a trailing ``[...]`` added
+    to indicate the missing text. This option The default is to use
+    ``multimailhook.emailMaxLineLength``. This option avoids sending
+    emails with overly long subject lines, but should not be needed if
+    the commit messages follow the Git convention (one short subject
+    line, then a blank line, then the message body). To disable line
+    truncation, set this option to 0.
+
 multimailhook.maxCommitEmails
     The maximum number of commit emails to send for a given change.
     When the number of patches is larger that this value, only the

--- a/t/email-content.d/accent-python2
+++ b/t/email-content.d/accent-python2
@@ -103,7 +103,7 @@ To stop receiving notification emails like this one, please contact
 Administrator <administrator@example.com>.
 EOF
 ######################################################################
-$ test_update 'refs/heads/mâstér' 'refs/heads/mâstér^' '-c' 'multimailhook.from=author' '-c' 'multimailhook.emailMaxLineLength=10'
+$ test_update 'refs/heads/mâstér' 'refs/heads/mâstér^' '-c' 'multimailhook.from=author' '-c' 'multimailhook.emailMaxLineLength=10' '-c' 'multimailhook.subjectMaxLength=0'
 Sending notification emails to: Refchange List <refchangelist@example.com>
 ######################################################################
 /usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
@@ -207,7 +207,7 @@ To stop receiving notification emails like this one, please contact
 Administrator <administrator@example.com>.
 EOF
 ######################################################################
-$ test_update 'refs/heads/mâstér' 'refs/heads/mâstér^' '-c' 'multimailhook.from=author' '-c' 'multimailhook.emailMaxLineLength=10' '-c' 'multimailhook.emailStrictUTF8=false'
+$ test_update 'refs/heads/mâstér' 'refs/heads/mâstér^' '-c' 'multimailhook.from=author' '-c' 'multimailhook.emailMaxLineLength=10' '-c' 'multimailhook.subjectMaxLength=0' '-c' 'multimailhook.emailStrictUTF8=false'
 Sending notification emails to: Refchange List <refchangelist@example.com>
 ######################################################################
 /usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF

--- a/t/email-content.d/accent-python3
+++ b/t/email-content.d/accent-python3
@@ -103,7 +103,7 @@ To stop receiving notification emails like this one, please contact
 Administrator <administrator@example.com>.
 EOF
 ######################################################################
-$ test_update 'refs/heads/mâstér' 'refs/heads/mâstér^' '-c' 'multimailhook.from=author' '-c' 'multimailhook.emailMaxLineLength=10'
+$ test_update 'refs/heads/mâstér' 'refs/heads/mâstér^' '-c' 'multimailhook.from=author' '-c' 'multimailhook.emailMaxLineLength=10' '-c' 'multimailhook.subjectMaxLength=0'
 Sending notification emails to: Refchange List <refchangelist@example.com>
 ######################################################################
 /usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
@@ -207,7 +207,7 @@ To stop receiving notification emails like this one, please contact
 Administrator <administrator@example.com>.
 EOF
 ######################################################################
-$ test_update 'refs/heads/mâstér' 'refs/heads/mâstér^' '-c' 'multimailhook.from=author' '-c' 'multimailhook.emailMaxLineLength=10' '-c' 'multimailhook.emailStrictUTF8=false'
+$ test_update 'refs/heads/mâstér' 'refs/heads/mâstér^' '-c' 'multimailhook.from=author' '-c' 'multimailhook.emailMaxLineLength=10' '-c' 'multimailhook.subjectMaxLength=0' '-c' 'multimailhook.emailStrictUTF8=false'
 Sending notification emails to: Refchange List <refchangelist@example.com>
 ######################################################################
 /usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF

--- a/t/email-content.d/max
+++ b/t/email-content.d/max
@@ -522,7 +522,7 @@ To stop receiving notification emails like this one, please contact
 Administrator <administrator@example.com>.
 EOF
 ######################################################################
-$ test_update 'refs/heads/formatting' 'formatting^^' '-c' 'multimailhook.emailMaxLines=1' '-c' 'multimailhook.emailMaxLineLength=10' '-c' 'multimailhook.subjectMaxLength=10'
+$ test_update 'refs/heads/formatting' 'formatting^^' '-c' 'multimailhook.emailMaxLines=0' '-c' 'multimailhook.emailMaxLineLength=0' '-c' 'multimailhook.subjectMaxLength=0'
 Sending notification emails to: Refchange List <refchangelist@example.com>
 ######################################################################
 /usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
@@ -550,8 +550,19 @@ This is an automated email from the git hooks/post-receive script.
 pushuser pushed a change to branch formatting
 in repository test-repo.
 
-    [...]
-... 12 lines suppressed ...
+    from 9194268  Subject line
+     new 850c489  Another subject line
+     new 8e11f7c  Commit without Cc: line.
+
+The 2 revisions listed above as "new" are entirely new to this
+repository and will be described in separate emails.  The revisions
+listed as "add" were already present in the repository and have only
+been added to this reference.
+
+
+Summary of changes:
+ foo.txt | 2 ++
+ 1 file changed, 2 insertions(+)
 
 -- 
 To stop receiving notification emails like this one, please contact
@@ -562,7 +573,7 @@ EOF
 /usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
 Date: ...
 To: Commit List <commitlist@example.com>
-Subject: *test-repo* 01/02: Anot [...]
+Subject: *test-repo* 01/02: Another subject line
 MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: 8bit
@@ -584,8 +595,27 @@ This is an automated email from the git hooks/post-receive script.
 pushuser pushed a commit to branch formatting
 in repository test-repo.
 
-com [...]
-... 20 lines suppressed ...
+commit 850c489cf431841cf428e00fc8285456682a9d13
+Author: Matthieu Moy <Matthieu.Moy@imag.fr>
+AuthorDate: Sun May 24 19:58:34 2015 +0200
+
+    Another subject line
+    
+    This is the body.
+    And below is the Cc: line.
+    Cc: me@example.com
+---
+ foo.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/foo.txt b/foo.txt
+index eec8bfc..f601cee 100644
+--- a/foo.txt
++++ b/foo.txt
+@@ -1,2 +1,3 @@
+ foo
+ new-content
++new-content
 
 -- 
 To stop receiving notification emails like this one, please contact
@@ -596,7 +626,7 @@ EOF
 /usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
 Date: ...
 To: Commit List <commitlist@example.com>
-Subject: *test-repo* 02/02: Comm [...]
+Subject: *test-repo* 02/02: Commit without Cc: line.
 MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: 8bit
@@ -618,8 +648,27 @@ This is an automated email from the git hooks/post-receive script.
 pushuser pushed a commit to branch formatting
 in repository test-repo.
 
-com [...]
-... 20 lines suppressed ...
+commit 8e11f7c6a6a86d37ac1f3e9ce6ec7d1399412c17
+Author: Matthieu Moy <Matthieu.Moy@imag.fr>
+AuthorDate: Sun May 24 20:19:12 2015 +0200
+
+    Commit without Cc: line.
+    
+    This commit contains Cc: within the text, but has to proper
+    CC: line.
+---
+ foo.txt | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/foo.txt b/foo.txt
+index f601cee..5167925 100644
+--- a/foo.txt
++++ b/foo.txt
+@@ -1,3 +1,4 @@
+ foo
+ new-content
+ new-content
++new-content
 
 -- 
 To stop receiving notification emails like this one, please contact

--- a/t/email-content.d/max
+++ b/t/email-content.d/max
@@ -354,7 +354,7 @@ EOF
 /usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
 Date: ...
 To: Commit List <commitlist@example.com>
-Subject: *test-repo* 01/02: Another subject line
+Subject: *test-repo* 01/02: Another s [...]
 MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: 8bit
@@ -388,7 +388,7 @@ EOF
 /usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
 Date: ...
 To: Commit List <commitlist@example.com>
-Subject: *test-repo* 02/02: Commit without Cc: line.
+Subject: *test-repo* 02/02: Commit wi [...]
 MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: 8bit
@@ -492,7 +492,7 @@ EOF
 /usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
 Date: ...
 To: Commit List <commitlist@example.com>
-Subject: *test-repo* 02/02: Commit without Cc: line.
+Subject: *test-repo* 02/02: Commit without [...]
 MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: 8bit
@@ -562,7 +562,7 @@ EOF
 /usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
 Date: ...
 To: Commit List <commitlist@example.com>
-Subject: *test-repo* 01/02: Another subject line
+Subject: *test-repo* 01/02: Anot [...]
 MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: 8bit
@@ -596,7 +596,7 @@ EOF
 /usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
 Date: ...
 To: Commit List <commitlist@example.com>
-Subject: *test-repo* 02/02: Commit without Cc: line.
+Subject: *test-repo* 02/02: Comm [...]
 MIME-Version: 1.0
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: 8bit

--- a/t/email-content.d/max
+++ b/t/email-content.d/max
@@ -314,3 +314,315 @@ To stop receiving notification emails like this one, please contact
 Administrator <administrator@example.com>.
 EOF
 ######################################################################
+$ test_update 'refs/heads/formatting' 'formatting^^' '-c' 'multimailhook.emailMaxLines=1' '-c' 'multimailhook.emailMaxLineLength=15'
+Sending notification emails to: Refchange List <refchangelist@example.com>
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: Refchange List <refchangelist@example.com>
+Subject: *test-repo* branch formatting updated (9194268 -> 8e11f7c)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+Message-ID: <...>
+From: From <from@example.com>
+Reply-To: pushuser@example.com
+X-Git-Host: fqdn.example.org
+X-Git-Repo: test-repo
+X-Git-Refname: refs/heads/formatting
+X-Git-Reftype: branch
+X-Git-Oldrev: 919426837aa07c18459a0acc0f789b6a8cd8fb80
+X-Git-Newrev: 8e11f7c6a6a86d37ac1f3e9ce6ec7d1399412c17
+X-Git-NotificationType: ref_changed
+X-Git-Multimail-Version: ...
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a change to branch formatting
+in repository test-repo.
+
+    from [...]
+... 12 lines suppressed ...
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+EOF
+######################################################################
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: Commit List <commitlist@example.com>
+Subject: *test-repo* 01/02: Another subject line
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+From: From <from@example.com>
+Reply-To: Matthieu Moy <Matthieu.Moy@imag.fr>
+In-Reply-To: <...>
+References: <...>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: test-repo
+X-Git-Refname: refs/heads/formatting
+X-Git-Reftype: branch
+X-Git-Rev: 850c489cf431841cf428e00fc8285456682a9d13
+X-Git-NotificationType: diff
+X-Git-Multimail-Version: ...
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a commit to branch formatting
+in repository test-repo.
+
+commit 8 [...]
+... 20 lines suppressed ...
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+EOF
+######################################################################
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: Commit List <commitlist@example.com>
+Subject: *test-repo* 02/02: Commit without Cc: line.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+From: From <from@example.com>
+Reply-To: Matthieu Moy <Matthieu.Moy@imag.fr>
+In-Reply-To: <...>
+References: <...>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: test-repo
+X-Git-Refname: refs/heads/formatting
+X-Git-Reftype: branch
+X-Git-Rev: 8e11f7c6a6a86d37ac1f3e9ce6ec7d1399412c17
+X-Git-NotificationType: diff
+X-Git-Multimail-Version: ...
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a commit to branch formatting
+in repository test-repo.
+
+commit 8 [...]
+... 20 lines suppressed ...
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+EOF
+######################################################################
+$ test_update 'refs/heads/formatting' 'formatting^^' '-c' 'multimailhook.emailMaxLines=1' '-c' 'multimailhook.emailMaxLineLength=15' '-c' 'multimailhook.subjectMaxLength=20'
+Sending notification emails to: Refchange List <refchangelist@example.com>
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: Refchange List <refchangelist@example.com>
+Subject: *test-repo* branch formatting updated (9194268 -> 8e11f7c)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+Message-ID: <...>
+From: From <from@example.com>
+Reply-To: pushuser@example.com
+X-Git-Host: fqdn.example.org
+X-Git-Repo: test-repo
+X-Git-Refname: refs/heads/formatting
+X-Git-Reftype: branch
+X-Git-Oldrev: 919426837aa07c18459a0acc0f789b6a8cd8fb80
+X-Git-Newrev: 8e11f7c6a6a86d37ac1f3e9ce6ec7d1399412c17
+X-Git-NotificationType: ref_changed
+X-Git-Multimail-Version: ...
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a change to branch formatting
+in repository test-repo.
+
+    from [...]
+... 12 lines suppressed ...
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+EOF
+######################################################################
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: Commit List <commitlist@example.com>
+Subject: *test-repo* 01/02: Another subject line
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+From: From <from@example.com>
+Reply-To: Matthieu Moy <Matthieu.Moy@imag.fr>
+In-Reply-To: <...>
+References: <...>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: test-repo
+X-Git-Refname: refs/heads/formatting
+X-Git-Reftype: branch
+X-Git-Rev: 850c489cf431841cf428e00fc8285456682a9d13
+X-Git-NotificationType: diff
+X-Git-Multimail-Version: ...
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a commit to branch formatting
+in repository test-repo.
+
+commit 8 [...]
+... 20 lines suppressed ...
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+EOF
+######################################################################
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: Commit List <commitlist@example.com>
+Subject: *test-repo* 02/02: Commit without Cc: line.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+From: From <from@example.com>
+Reply-To: Matthieu Moy <Matthieu.Moy@imag.fr>
+In-Reply-To: <...>
+References: <...>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: test-repo
+X-Git-Refname: refs/heads/formatting
+X-Git-Reftype: branch
+X-Git-Rev: 8e11f7c6a6a86d37ac1f3e9ce6ec7d1399412c17
+X-Git-NotificationType: diff
+X-Git-Multimail-Version: ...
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a commit to branch formatting
+in repository test-repo.
+
+commit 8 [...]
+... 20 lines suppressed ...
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+EOF
+######################################################################
+$ test_update 'refs/heads/formatting' 'formatting^^' '-c' 'multimailhook.emailMaxLines=1' '-c' 'multimailhook.emailMaxLineLength=10' '-c' 'multimailhook.subjectMaxLength=10'
+Sending notification emails to: Refchange List <refchangelist@example.com>
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: Refchange List <refchangelist@example.com>
+Subject: *test-repo* branch formatting updated (9194268 -> 8e11f7c)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+Message-ID: <...>
+From: From <from@example.com>
+Reply-To: pushuser@example.com
+X-Git-Host: fqdn.example.org
+X-Git-Repo: test-repo
+X-Git-Refname: refs/heads/formatting
+X-Git-Reftype: branch
+X-Git-Oldrev: 919426837aa07c18459a0acc0f789b6a8cd8fb80
+X-Git-Newrev: 8e11f7c6a6a86d37ac1f3e9ce6ec7d1399412c17
+X-Git-NotificationType: ref_changed
+X-Git-Multimail-Version: ...
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a change to branch formatting
+in repository test-repo.
+
+    [...]
+... 12 lines suppressed ...
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+EOF
+######################################################################
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: Commit List <commitlist@example.com>
+Subject: *test-repo* 01/02: Another subject line
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+From: From <from@example.com>
+Reply-To: Matthieu Moy <Matthieu.Moy@imag.fr>
+In-Reply-To: <...>
+References: <...>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: test-repo
+X-Git-Refname: refs/heads/formatting
+X-Git-Reftype: branch
+X-Git-Rev: 850c489cf431841cf428e00fc8285456682a9d13
+X-Git-NotificationType: diff
+X-Git-Multimail-Version: ...
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a commit to branch formatting
+in repository test-repo.
+
+com [...]
+... 20 lines suppressed ...
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+EOF
+######################################################################
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: Commit List <commitlist@example.com>
+Subject: *test-repo* 02/02: Commit without Cc: line.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+From: From <from@example.com>
+Reply-To: Matthieu Moy <Matthieu.Moy@imag.fr>
+In-Reply-To: <...>
+References: <...>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: test-repo
+X-Git-Refname: refs/heads/formatting
+X-Git-Reftype: branch
+X-Git-Rev: 8e11f7c6a6a86d37ac1f3e9ce6ec7d1399412c17
+X-Git-NotificationType: diff
+X-Git-Multimail-Version: ...
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a commit to branch formatting
+in repository test-repo.
+
+com [...]
+... 20 lines suppressed ...
+
+-- 
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com>.
+EOF
+######################################################################

--- a/t/email-content.t
+++ b/t/email-content.t
@@ -183,7 +183,18 @@ test_email_content 'restrict email count and size' max '
 	verbose_do test_update refs/heads/master foo \
 		-c multimailhook.refFilterDontSendRegex=^refs/heads/feature$ \
 		-c multimailhook.emailMaxLines=10 \
-		-c multimailhook.emailMaxLineLength=15
+		-c multimailhook.emailMaxLineLength=15 &&
+	verbose_do test_update refs/heads/formatting formatting^^ \
+		-c multimailhook.emailMaxLines=1 \
+		-c multimailhook.emailMaxLineLength=15 &&
+	verbose_do test_update refs/heads/formatting formatting^^ \
+		-c multimailhook.emailMaxLines=1 \
+		-c multimailhook.emailMaxLineLength=15 \
+		-c multimailhook.subjectMaxLength=20 &&
+	verbose_do test_update refs/heads/formatting formatting^^ \
+		-c multimailhook.emailMaxLines=1 \
+		-c multimailhook.emailMaxLineLength=10 \
+		-c multimailhook.subjectMaxLength=10
 '
 
 test_email_content 'refFilter inclusion/exclusion/doSend/DontSend' ref-filter '
@@ -248,10 +259,12 @@ test_email_content '' 'test_when_finished "git checkout master && git branch -D 
 		 -c multimailhook.from=author &&
 	verbose_do test_update refs/heads/mâstér refs/heads/mâstér^ \
 		-c multimailhook.from=author \
-		-c multimailhook.emailMaxLineLength=10 &&
+		-c multimailhook.emailMaxLineLength=10 \
+		-c multimailhook.subjectMaxLength=0 &&
 	verbose_do test_update refs/heads/mâstér refs/heads/mâstér^ \
 		-c multimailhook.from=author \
 		-c multimailhook.emailMaxLineLength=10 \
+		-c multimailhook.subjectMaxLength=0 \
 		-c multimailhook.emailStrictUTF8=false
 '
 

--- a/t/email-content.t
+++ b/t/email-content.t
@@ -192,9 +192,9 @@ test_email_content 'restrict email count and size' max '
 		-c multimailhook.emailMaxLineLength=15 \
 		-c multimailhook.subjectMaxLength=20 &&
 	verbose_do test_update refs/heads/formatting formatting^^ \
-		-c multimailhook.emailMaxLines=1 \
-		-c multimailhook.emailMaxLineLength=10 \
-		-c multimailhook.subjectMaxLength=10
+		-c multimailhook.emailMaxLines=0 \
+		-c multimailhook.emailMaxLineLength=0 \
+		-c multimailhook.subjectMaxLength=0
 '
 
 test_email_content 'refFilter inclusion/exclusion/doSend/DontSend' ref-filter '


### PR DESCRIPTION
Implement a new option multimailhook.subjectMaxLength to truncate overly long subject lines.