### PR TITLE
The environment parameter is required now for the constructor invocat…

### DIFF
--- a/git-multimail/post-receive.example
+++ b/git-multimail/post-receive.example
@@ -86,6 +86,7 @@ mailer = git_multimail.choose_mailer(config, environment)
 
 # Use Python's smtplib to send emails.  Both arguments are required.
 #mailer = git_multimail.SMTPMailer(
+#    environment=environment,
 #    envelopesender='git-repo@example.com',
 #    # The smtpserver argument can also include a port number; e.g.,
 #    #     smtpserver='mail.example.com:25'


### PR DESCRIPTION
I updated to git-multimail 1.4.0 today and noticed that the environment parameter is required when constructing an SMTPMailer.

Updated the example as it was missing this info.