### PR TITLE
Fixing Issue #181

### DIFF
--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -2054,6 +2054,7 @@ class SMTPMailer(Mailer):
         self.username = smtpuser
         self.password = smtppass
         self.smtpcacerts = smtpcacerts
+        self.loggedin = ''
         try:
             def call(klass, server, timeout):
                 try:
@@ -2138,7 +2139,9 @@ class SMTPMailer(Mailer):
     def send(self, lines, to_addrs):
         try:
             if self.username or self.password:
-                self.smtp.login(self.username, self.password)
+                if not self.loggedin:
+                    self.smtp.login(self.username, self.password)
+                    self.loggedin = 'true'
             msg = ''.join(lines)
             # turn comma-separated list into Python list if needed.
             if is_string(to_addrs):

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -2141,7 +2141,7 @@ class SMTPMailer(Mailer):
             if self.username or self.password:
                 if not self.loggedin:
                     self.smtp.login(self.username, self.password)
-                    self.loggedin = 'true'
+                    self.loggedin = True
             msg = ''.join(lines)
             # turn comma-separated list into Python list if needed.
             if is_string(to_addrs):


### PR DESCRIPTION
Hi, as I needed it solved I attempted to solve it. 

The bug was that after sending 4 emails the rest in a big push were rejected by my mail server. My mail server doesn't like attempts to re-authenticate after each email, so after 4 emails the next attempt was a 4th error that caused it to close the connection. 

Now there is a simple flag limiting the authentication to just the first message.

Unsure if this bug was new due to changes in smtplib or because my mail server is broken. Or if the code was always a little broken. This functionality might need to be hidden behind a option if others report that this wasn't broken for them and now it is.

100% expect this to be knocked back for any number of reasons. But it does work for me, where the current code doesn't.

Please 