### PR TITLE
User mail map

### DIFF
--- a/git-multimail/README.rst
+++ b/git-multimail/README.rst
@@ -423,8 +423,20 @@ multimailhook.from, multimailhook.fromCommit, multimailhook.fromRefchange
     If config values are unset, the value of the From: header is
     determined as follows:
 
-    1. (gitolite environment only) Parse gitolite.conf, looking for a
-       block of comments that looks like this::
+    1. (gitolite environment only)
+       1.a) If ``multimailhook.MailaddressMap`` is set, and is a path
+       to an existing file (if relative, it is considered relative to
+       the place where ``gitolite.conf`` is located), then this file
+       should contain lines like::
+
+           username Firstname Lastname <email@example.com>
+
+       git-multimail will then look for a line where ``$GL_USER``
+       matches the ``username`` part, and use the rest of the line for
+       the ``From:`` header.
+
+       1.b) Parse gitolite.conf, looking for a block of comments that
+       looks like this::
 
            # BEGIN USER EMAILS
            # username Firstname Lastname <email@example.com>
@@ -439,6 +451,11 @@ multimailhook.from, multimailhook.fromCommit, multimailhook.fromRefchange
        (and the value of user.name, if set).
 
     3. Use the value of multimailhook.envelopeSender.
+
+multimailhook.MailaddressMap
+    (gitolite environment only)
+    File to look for a ``From:`` address based on the user doing the
+    push. Defaults to unset. See ``multimailhook.from`` for details.
 
 multimailhook.administrator
     The name and/or email address of the administrator of the Git

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -3179,6 +3179,16 @@ class GitoliteEnvironmentLowPrecMixin(Environment):
             super(GitoliteEnvironmentLowPrecMixin, self).get_repo_shortname()
             )
 
+    @staticmethod
+    def _compile_regex(re_template):
+        return (
+            re.compile(re_template % x)
+            for x in (
+                r'BEGIN\s+USER\s+EMAILS',
+                '([^\s]+)\s+(.*)',
+                r'END\s+USER\s+EMAILS',
+                ))
+
     def get_fromaddr(self, change=None):
         GL_USER = self.osenv.get('GL_USER')
         if GL_USER is not None:
@@ -3195,14 +3205,8 @@ class GitoliteEnvironmentLowPrecMixin(Environment):
                 f = open(GL_CONF, 'rU')
                 try:
                     in_user_emails_section = False
-                    re_template = r'^\s*#\s*%s\s*$'
-                    re_begin, re_user, re_end = (
-                        re.compile(re_template % x)
-                        for x in (
-                            r'BEGIN\s+USER\s+EMAILS',
-                            re.escape(GL_USER) + r'\s+(.*)',
-                            r'END\s+USER\s+EMAILS',
-                            ))
+                    re_begin, re_user, re_end = self._compile_regex(
+                        r'^\s*#\s*%s\s*$')
                     for l in f:
                         l = l.rstrip('\n')
                         if not in_user_emails_section:
@@ -3212,8 +3216,8 @@ class GitoliteEnvironmentLowPrecMixin(Environment):
                         if re_end.match(l):
                             break
                         m = re_user.match(l)
-                        if m:
-                            return m.group(1)
+                        if m and m.group(1) == GL_USER:
+                            return m.group(2)
                 finally:
                     f.close()
         return super(GitoliteEnvironmentLowPrecMixin, self).get_fromaddr(change)

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -3169,7 +3169,10 @@ class GitoliteEnvironmentHighPrecMixin(Environment):
         return self.osenv.get('GL_USER', 'unknown user')
 
 
-class GitoliteEnvironmentLowPrecMixin(Environment):
+class GitoliteEnvironmentLowPrecMixin(
+        ConfigEnvironmentMixin,
+        Environment):
+
     def get_repo_shortname(self):
         # The gitolite environment variable $GL_REPO is a pretty good
         # repo_shortname (though it's probably not as good as a value
@@ -3201,6 +3204,36 @@ class GitoliteEnvironmentLowPrecMixin(Environment):
             GL_CONF = self.osenv.get(
                 'GL_CONF',
                 os.path.join(GL_ADMINDIR, 'conf', 'gitolite.conf'))
+
+            mailaddress_map = self.config.get('MailaddressMap')
+            # If relative, consider relative to GL_CONF:
+            if mailaddress_map:
+                mailaddress_map = os.path.join(os.path.dirname(GL_CONF),
+                                               mailaddress_map)
+                if os.path.isfile(mailaddress_map):
+                    f = open(mailaddress_map, 'rU')
+                    try:
+                        # Leading '#' is optional
+                        re_begin, re_user, re_end = self._compile_regex(
+                            r'^(?:\s*#)?\s*%s\s*$')
+                        for l in f:
+                            l = l.rstrip('\n')
+                            if re_begin.match(l) or re_end.match(l):
+                                continue  # Ignore these lines
+                            m = re_user.match(l)
+                            if m:
+                                if m.group(1) == GL_USER:
+                                    return m.group(2)
+                                else:
+                                    continue  # Not this user, but not an error
+                            raise ConfigurationException(
+                                "Syntax error in mail address map.\n"
+                                "Check file {}.\n"
+                                "Line: {}".format(mailaddress_map, l))
+
+                    finally:
+                        f.close()
+
             if os.path.isfile(GL_CONF):
                 f = open(GL_CONF, 'rU')
                 try:

--- a/t/conf/user-mailaddress-map
+++ b/t/conf/user-mailaddress-map
@@ -1,0 +1,2 @@
+gluser1 Some Other In Map <some.other.in.map@example.com>
+gluser Some Guy In Map <some.guy.in.map@example.com>

--- a/t/test-env
+++ b/t/test-env
@@ -325,6 +325,11 @@ GITOLITE_RC_ENVIRONMENT.update(
     fromaddr='Some Guy <some.guy@example.com>'
     )
 
+GITOLITE_MAP_ENVIRONMENT = GITOLITE_ENVIRONMENT.copy()
+GITOLITE_MAP_ENVIRONMENT.update(
+    fromaddr='Some Guy In Map <some.guy.in.map@example.com>'
+    )
+
 FROM = 'From Fellow <from@example.com>'
 ADMIN = 'Admin Guy <admin@example.com>'
 ENVELOPE = 'Flat Stanley <stanley@example.com>'
@@ -344,6 +349,12 @@ def suite():
     suite.addTest(GitoliteEnvTest('basic gitolite test',
                                   osenv=osenv,
                                   tests=GITOLITE_RC_ENVIRONMENT))
+
+    mailmap_config = {'MailaddressMap': 'user-mailaddress-map'}
+    suite.addTest(GitoliteEnvTest('gitolite test with multimailhook.MailaddressMap',
+                                  osenv=osenv,
+                                  extra_config=mailmap_config,
+                                  tests=GITOLITE_MAP_ENVIRONMENT))
 
     for test in [GenericEnvTest, GitoliteEnvTest]:
         suite.addTests([


### PR DESCRIPTION
When dealing with multiple gitolite instances, one may want to
replicate the mail map on every instances, but keep a per-instance
gitolite.conf files. Having two separate files makes this possible.

Fixes #187.