### PR TITLE
Add a Thread-Index header for proper threading in Outlook

### DIFF
--- a/git-multimail/CHANGES
+++ b/git-multimail/CHANGES
@@ -7,6 +7,17 @@ Backward-incompatible change
 The name of classes for environment was misnamed as `*Environement`.
 It is now `*Environment`.
 
+New features
+------------
+
+* A Thread-Index header is now added to each email sent (except for
+  combined emails where it would not make sense), so that MS Outlook
+  properly groups messages by threads even though they have a
+  different subject line. Unfortunately, even adding this header the
+  threading still seems to be unreliable, but it is unclear whether
+  this is an issue on our side or on MS Outlook's side (see discussion
+  here: https://github.com/git-multimail/git-multimail/pull/194).
+
 Internal changes
 ----------------
 

--- a/t/email-content.d/accent-python2
+++ b/t/email-content.d/accent-python2
@@ -12,6 +12,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: Joe User <user@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: =?utf-8?q?refs/heads/m=C3=A2st=C3=A9r?=
@@ -58,6 +59,7 @@ From: =?utf-8?q?S=C3=A9bastien?= <sebastien@example.com>
 Reply-To: =?utf-8?q?S=C3=A9bastien?= <sebastien@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: =?utf-8?q?refs/heads/m=C3=A2st=C3=A9r?=
@@ -116,6 +118,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: Joe User <user@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: =?utf-8?q?refs/heads/m=C3=A2st=C3=A9r?=
@@ -162,6 +165,7 @@ From: =?utf-8?q?S=C3=A9bastien?= <sebastien@example.com>
 Reply-To: =?utf-8?q?S=C3=A9bastien?= <sebastien@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: =?utf-8?q?refs/heads/m=C3=A2st=C3=A9r?=
@@ -220,6 +224,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: Joe User <user@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: =?utf-8?q?refs/heads/m=C3=A2st=C3=A9r?=
@@ -266,6 +271,7 @@ From: =?utf-8?q?S=C3=A9bastien?= <sebastien@example.com>
 Reply-To: =?utf-8?q?S=C3=A9bastien?= <sebastien@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: =?utf-8?q?refs/heads/m=C3=A2st=C3=A9r?=

--- a/t/email-content.d/accent-python3
+++ b/t/email-content.d/accent-python3
@@ -12,6 +12,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: Joe User <user@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: =?utf-8?q?refs/heads/m=C3=A2st=C3=A9r?=
@@ -58,6 +59,7 @@ From: =?utf-8?q?S=C3=A9bastien?= <sebastien@example.com>
 Reply-To: =?utf-8?q?S=C3=A9bastien?= <sebastien@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: =?utf-8?q?refs/heads/m=C3=A2st=C3=A9r?=
@@ -116,6 +118,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: Joe User <user@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: =?utf-8?q?refs/heads/m=C3=A2st=C3=A9r?=
@@ -162,6 +165,7 @@ From: =?utf-8?q?S=C3=A9bastien?= <sebastien@example.com>
 Reply-To: =?utf-8?q?S=C3=A9bastien?= <sebastien@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: =?utf-8?q?refs/heads/m=C3=A2st=C3=A9r?=
@@ -220,6 +224,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: Joe User <user@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: =?utf-8?q?refs/heads/m=C3=A2st=C3=A9r?=
@@ -266,6 +271,7 @@ From: =?utf-8?q?S=C3=A9bastien?= <sebastien@example.com>
 Reply-To: =?utf-8?q?S=C3=A9bastien?= <sebastien@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: =?utf-8?q?refs/heads/m=C3=A2st=C3=A9r?=

--- a/t/email-content.d/all
+++ b/t/email-content.d/all
@@ -10,6 +10,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -65,6 +66,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -115,6 +117,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -163,6 +166,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: John O'Connor <john@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -230,6 +234,7 @@ From: John O'Connor <john@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -278,6 +283,7 @@ From: John O'Connor <john@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -326,6 +332,7 @@ From: John O'Connor <john@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -374,6 +381,7 @@ From: John O'Connor <john@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -424,6 +432,7 @@ From: John O'Connor <john@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -472,6 +481,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -514,6 +524,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -568,6 +579,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -631,6 +643,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -681,6 +694,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/release
@@ -729,6 +743,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/release
@@ -777,6 +792,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/release
@@ -825,6 +841,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/release
@@ -870,6 +887,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/release
@@ -973,6 +991,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/release
@@ -1018,6 +1037,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/release
@@ -1067,6 +1087,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/release
@@ -1124,6 +1145,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/feature
@@ -1169,6 +1191,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/feature
@@ -1217,6 +1240,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/feature
@@ -1265,6 +1289,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/feature
@@ -1312,6 +1337,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/feature
@@ -1360,6 +1386,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/feature
@@ -1408,6 +1435,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/feature
@@ -1460,6 +1488,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/feature
@@ -1502,6 +1531,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/remotes/remote
@@ -1547,6 +1577,7 @@ From: Joe User <user@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/remotes/remote
@@ -1595,6 +1626,7 @@ From: Joe User <user@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/remotes/remote
@@ -1645,6 +1677,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/remotes/remote
@@ -1715,6 +1748,7 @@ From: Joe User <user@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/remotes/remote
@@ -1763,6 +1797,7 @@ From: Joe User <user@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/remotes/remote
@@ -1814,6 +1849,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From RefChange <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/remotes/remote
@@ -1855,6 +1891,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From RefChange <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/foo/bar
@@ -1899,6 +1936,7 @@ From: =?utf-8?q?Jo=C3=ABl_User?= <user@example.com>
 Reply-To: =?utf-8?q?Jo=C3=ABl_User?= <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/foo/bar
@@ -1949,6 +1987,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From RefChange <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/foo/bar
@@ -2018,6 +2057,7 @@ From: =?utf-8?q?Jo=C3=ABl_User?= <user@example.com>
 Reply-To: =?utf-8?q?Jo=C3=ABl_User?= <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/foo/bar
@@ -2072,6 +2112,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: pushuser@example.com
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/foo/bar
@@ -2111,6 +2152,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: pushuser@example.com
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -2160,6 +2202,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -2210,6 +2253,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -2261,6 +2305,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: pushuser@example.com
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/formatting
@@ -2310,6 +2355,7 @@ From: From <from@example.com>
 Reply-To: Matthieu Moy <Matthieu.Moy@imag.fr>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/formatting
@@ -2363,6 +2409,7 @@ From: From <from@example.com>
 Reply-To: Matthieu Moy <Matthieu.Moy@imag.fr>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/formatting
@@ -2416,6 +2463,7 @@ From: From <from@example.com>
 Reply-To: Matthieu Moy <Matthieu.Moy@imag.fr>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/formatting
@@ -2475,6 +2523,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -2553,6 +2602,7 @@ From: From <from@example.com>
 Reply-To: Matthieu Moy <Matthieu.Moy@imag.fr>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/formatting
@@ -2605,6 +2655,7 @@ From: From <from@example.com>
 Reply-To: Matthieu Moy <Matthieu.Moy@imag.fr>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/formatting

--- a/t/email-content.d/annotated-tag
+++ b/t/email-content.d/annotated-tag
@@ -11,6 +11,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/tags/tag-annotated
@@ -61,6 +62,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/tags/tag-annotated
@@ -146,6 +148,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/tags/tag-annotated

--- a/t/email-content.d/annotated-tag-content
+++ b/t/email-content.d/annotated-tag-content
@@ -11,6 +11,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/tags/tag-annotated-new-content
@@ -69,6 +70,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/tags/tag-annotated-new-content
@@ -117,6 +119,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/tags/tag-annotated-new-content
@@ -166,6 +169,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/tags/tag-annotated-new-content
@@ -254,6 +258,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/tags/tag-annotated-new-content
@@ -302,6 +307,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/tags/tag-annotated-new-content
@@ -351,6 +357,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/tags/tag-annotated-new-content

--- a/t/email-content.d/annotated-tag-tree
+++ b/t/email-content.d/annotated-tag-tree
@@ -11,6 +11,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/tags/tree-tag
@@ -58,6 +59,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/tags/tree-tag
@@ -108,6 +110,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/tags/tree-tag
@@ -149,6 +152,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/tags/recursive-tag
@@ -194,6 +198,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/tags/recursive-tag
@@ -274,6 +279,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/tags/recursive-tag

--- a/t/email-content.d/create-master
+++ b/t/email-content.d/create-master
@@ -10,6 +10,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -58,6 +59,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -106,6 +108,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -154,6 +157,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -202,6 +206,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -252,6 +257,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master

--- a/t/email-content.d/diff-log
+++ b/t/email-content.d/diff-log
@@ -10,6 +10,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -80,6 +81,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -118,6 +120,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master

--- a/t/email-content.d/emailprefix
+++ b/t/email-content.d/emailprefix
@@ -11,6 +11,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -60,6 +61,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -110,6 +112,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master

--- a/t/email-content.d/gerrit
+++ b/t/email-content.d/gerrit
@@ -12,6 +12,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: =?utf-8?q?S=C3=BBb_Mitter?= <sub.mitter@example.com>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: =?utf-8?q?refs/heads/mast=C3=A8r?=
@@ -55,6 +56,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: =?utf-8?q?refs/heads/mast=C3=A8r?=
@@ -104,6 +106,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: =?utf-8?q?Sub_M=C3=AEtter?= <sub.mitter@example.com>
 Reply-To: =?utf-8?q?Sub_M=C3=AEtter?= <sub.mitter@example.com>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: demo-project
 X-Git-Refname: refs/heads/master
@@ -147,6 +150,7 @@ From: =?utf-8?q?Sub_M=C3=AEtter?= <sub.mitter@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: demo-project
 X-Git-Refname: refs/heads/master
@@ -194,6 +198,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: Joe User <user@example.com>
 Reply-To: Submitter
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -237,6 +242,7 @@ From: Joe User <user@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master

--- a/t/email-content.d/head
+++ b/t/email-content.d/head
@@ -12,6 +12,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: HEAD

--- a/t/email-content.d/headers
+++ b/t/email-content.d/headers
@@ -22,6 +22,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: from-config@example.com
 Reply-To: reply-to-config@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -71,6 +72,7 @@ From: from-config@example.com
 Reply-To: reply-to-config@example.com
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -121,6 +123,7 @@ From: from-config@example.com
 Reply-To: reply-to-config@example.com
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master

--- a/t/email-content.d/headers-specific
+++ b/t/email-content.d/headers-specific
@@ -11,6 +11,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: from-refchange@example.com
 Reply-To: reply-to-refchange@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -60,6 +61,7 @@ From: from-commit@example.com
 Reply-To: reply-to-commit@example.com
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -110,6 +112,7 @@ From: from-commit@example.com
 Reply-To: reply-to-commit@example.com
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master

--- a/t/email-content.d/html
+++ b/t/email-content.d/html
@@ -10,6 +10,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -59,6 +60,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -113,6 +115,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master

--- a/t/email-content.d/html-templates
+++ b/t/email-content.d/html-templates
@@ -11,6 +11,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: name<with>special&chars;.git
 X-Git-Refname: refs/heads/master
@@ -61,6 +62,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: name<with>special&chars;.git
 X-Git-Refname: refs/heads/master
@@ -118,6 +120,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: name<with>special&chars;.git
 X-Git-Refname: refs/heads/master
@@ -174,6 +177,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: name<with>special&chars;.git
 X-Git-Refname: refs/heads/master
@@ -224,6 +228,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: name<with>special&chars;.git
 X-Git-Refname: refs/heads/master
@@ -279,6 +284,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: name<with>special&chars;.git
 X-Git-Refname: refs/heads/master
@@ -333,6 +339,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: name<with>special&chars;.git
 X-Git-Refname: refs/heads/master
@@ -383,6 +390,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: name<with>special&chars;.git
 X-Git-Refname: refs/heads/master
@@ -436,6 +444,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: name<with>special&chars;.git
 X-Git-Refname: refs/heads/master

--- a/t/email-content.d/max
+++ b/t/email-content.d/max
@@ -14,6 +14,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -67,6 +68,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -111,6 +113,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -154,6 +157,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -197,6 +201,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -240,6 +245,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -283,6 +289,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -327,6 +334,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/formatting
@@ -362,6 +370,7 @@ From: From <from@example.com>
 Reply-To: Matthieu Moy <Matthieu.Moy@imag.fr>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/formatting
@@ -396,6 +405,7 @@ From: From <from@example.com>
 Reply-To: Matthieu Moy <Matthieu.Moy@imag.fr>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/formatting
@@ -431,6 +441,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/formatting
@@ -466,6 +477,7 @@ From: From <from@example.com>
 Reply-To: Matthieu Moy <Matthieu.Moy@imag.fr>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/formatting
@@ -500,6 +512,7 @@ From: From <from@example.com>
 Reply-To: Matthieu Moy <Matthieu.Moy@imag.fr>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/formatting
@@ -535,6 +548,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/formatting
@@ -581,6 +595,7 @@ From: From <from@example.com>
 Reply-To: Matthieu Moy <Matthieu.Moy@imag.fr>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/formatting
@@ -634,6 +649,7 @@ From: From <from@example.com>
 Reply-To: Matthieu Moy <Matthieu.Moy@imag.fr>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/formatting

--- a/t/email-content.d/ref-filter
+++ b/t/email-content.d/ref-filter
@@ -25,6 +25,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -74,6 +75,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -122,6 +124,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -170,6 +173,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -218,6 +222,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -268,6 +273,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -318,6 +324,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -367,6 +374,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -417,6 +425,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -468,6 +477,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -520,6 +530,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -568,6 +579,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -616,6 +628,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -664,6 +677,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -714,6 +728,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -769,6 +784,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -821,6 +837,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -869,6 +886,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -917,6 +935,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -965,6 +984,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -1013,6 +1033,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -1061,6 +1082,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -1109,6 +1131,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -1159,6 +1182,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master

--- a/t/email-content.d/simple-tag
+++ b/t/email-content.d/simple-tag
@@ -10,6 +10,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/tags/tag
@@ -45,6 +46,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/tags/tag
@@ -115,6 +117,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/tags/tag

--- a/t/email-content.d/stash
+++ b/t/email-content.d/stash
@@ -10,6 +10,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: =?utf-8?q?Stash_S=C3=BBb_Mitter?= <sub.mitter@example.com>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -53,6 +54,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -100,6 +102,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: =?utf-8?q?Stash_Sub_M=C3=AEtter?= <sub.mitter@example.com>
 Reply-To: =?utf-8?q?Stash_Sub_M=C3=AEtter?= <sub.mitter@example.com>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: =?utf-8?q?stash-d=C3=A9mo-project?=
 X-Git-Refname: refs/heads/master
@@ -143,6 +146,7 @@ From: =?utf-8?q?Stash_Sub_M=C3=AEtter?= <sub.mitter@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: =?utf-8?q?stash-d=C3=A9mo-project?=
 X-Git-Refname: refs/heads/master

--- a/t/email-content.d/url
+++ b/t/email-content.d/url
@@ -10,6 +10,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -55,6 +56,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -108,6 +110,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -153,6 +156,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -204,6 +208,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -249,6 +254,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -302,6 +308,7 @@ Content-Transfer-Encoding: 8bit
 Message-ID: <...>
 From: From <from@example.com>
 Reply-To: pushuser@example.com
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master
@@ -347,6 +354,7 @@ From: From <from@example.com>
 Reply-To: Joe User <user@example.com>
 In-Reply-To: <...>
 References: <...>
+Thread-Index: <...>
 X-Git-Host: fqdn.example.org
 X-Git-Repo: test-repo
 X-Git-Refname: refs/heads/master

--- a/t/filter-noise
+++ b/t/filter-noise
@@ -4,11 +4,12 @@
 # the next.
 
 perl -pe 'BEGIN{undef $/;}
-s/^(In-Reply-To|Message-ID|References|Date|X-Git-Host|X-Git-Multimail-Version|Subject): \n +/\1: /mg;
-s/^(In-Reply-To|Message-ID|References|Date|X-Git-Host|X-Git-Multimail-Version|Subject): (.*)\n +/\1: \2 /mg;
+s/^(In-Reply-To|Message-ID|References|Date|X-Git-Host|X-Git-Multimail-Version|Subject|Thread-Index): \n +/\1: /mg;
+s/^(In-Reply-To|Message-ID|References|Date|X-Git-Host|X-Git-Multimail-Version|Subject|Thread-Index): (.*)\n +/\1: \2 /mg;
 ' |
 sed \
     -e 's/^\(In-Reply-To\|Message-ID\|References\): <.*>$/\1: <...>/' \
+    -e 's/^\(Thread-Index:\) .*$/\1 <...>/' \
     -e 's/^\(Date\): [^ ].*$/\1: .../' \
     -e "s/^\(X-Git-Host\): `hostname --fqdn`\$/\1: fqdn.example.org/" \
     -e "s/^\(X-Git-Multimail-Version\): $MULTIMAIL_VERSION_QUOTED/\1: .../" \


### PR DESCRIPTION
Fixes #192.

MS Outlook doesn't group messages by thread when the subject lines are
different, unless a Thread-Index header is present. See the
specification here:
https://msdn.microsoft.com/en-us/library/ee202481%28v=exchg.80%29 and
a discussion https://bugzilla.mozilla.org/show_bug.cgi?id=411601.

Tests and detailed commit message by: Matthieu Moy
<git@matthieu-moy.fr>

Original-patch-by: Björn Kautler <Bjoern@Kautler.net>
Signed-off-by: Björn Kautler <Bjoern@Kautler.net>
Signed-off-by: Matthieu Moy <git@matthieu-moy.fr>