### PR TITLE
Introduce excludeMergeRevisions config variable

### DIFF
--- a/git-multimail/README.rst
+++ b/git-multimail/README.rst
@@ -505,6 +505,11 @@ multimailhook.maxCommitEmails
     mailbombing, for example on an initial push.  To disable commit
     emails limit, set this option to 0.  The default is 500.
 
+multimailhook.excludeMergeRevisions
+    When sending out revision emails, do not consider merge commits (the
+    functional equivalent of `rev-list --no-merges`).
+    The default is `false` (send merge commit emails).
+
 multimailhook.emailStrictUTF8
     If this boolean option is set to `true`, then the main part of the
     email body is forced to be valid UTF-8.  Any characters that are

--- a/t/email-content.d/html-templates
+++ b/t/email-content.d/html-templates
@@ -71,6 +71,8 @@ X-Git-Rev: d245c99162aff6fff4879e5d5c17d454766b45db
 X-Git-NotificationType: diff
 X-Git-Multimail-Version: ...
 Auto-Submitted: auto-generated
+X-Git-Parents: ebf40e1fe61e9b74334f80b1e8af506a36ddb57f
+ abb8baa7170a6d55bc4311cc819579a929eb0b04
 
 <pre style='margin:0'>
 &lt;span style=&quot;color:#808080&quot;&gt;This is an automated email from the git hooks/post-receive script.&lt;/span&gt;&lt;br /&gt;&lt;br /&gt;
@@ -129,6 +131,7 @@ X-Git-Rev: 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
 X-Git-NotificationType: diff
 X-Git-Multimail-Version: ...
 Auto-Submitted: auto-generated
+X-Git-Parents: d245c99162aff6fff4879e5d5c17d454766b45db
 
 <pre style='margin:0'>
 &lt;span style=&quot;color:#808080&quot;&gt;This is an automated email from the git hooks/post-receive script.&lt;/span&gt;&lt;br /&gt;&lt;br /&gt;
@@ -237,6 +240,8 @@ X-Git-Rev: d245c99162aff6fff4879e5d5c17d454766b45db
 X-Git-NotificationType: diff
 X-Git-Multimail-Version: ...
 Auto-Submitted: auto-generated
+X-Git-Parents: ebf40e1fe61e9b74334f80b1e8af506a36ddb57f
+ abb8baa7170a6d55bc4311cc819579a929eb0b04
 
 <span style="color:#808080">This is an automated email from the git hooks/post-receive script.</span><br /><br />
 
@@ -293,6 +298,7 @@ X-Git-Rev: 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
 X-Git-NotificationType: diff
 X-Git-Multimail-Version: ...
 Auto-Submitted: auto-generated
+X-Git-Parents: d245c99162aff6fff4879e5d5c17d454766b45db
 
 <span style="color:#808080">This is an automated email from the git hooks/post-receive script.</span><br /><br />
 
@@ -399,6 +405,8 @@ X-Git-Rev: d245c99162aff6fff4879e5d5c17d454766b45db
 X-Git-NotificationType: diff
 X-Git-Multimail-Version: ...
 Auto-Submitted: auto-generated
+X-Git-Parents: ebf40e1fe61e9b74334f80b1e8af506a36ddb57f
+ abb8baa7170a6d55bc4311cc819579a929eb0b04
 
 <span style="color:#808080">This is an automated email from the git hooks/post-receive script.</span><br /><br />
 
@@ -453,6 +461,7 @@ X-Git-Rev: 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
 X-Git-NotificationType: diff
 X-Git-Multimail-Version: ...
 Auto-Submitted: auto-generated
+X-Git-Parents: d245c99162aff6fff4879e5d5c17d454766b45db
 
 <span style="color:#808080">This is an automated email from the git hooks/post-receive script.</span><br /><br />
 

--- a/t/email-content.d/ignoremerges
+++ b/t/email-content.d/ignoremerges
@@ -1,0 +1,104 @@
+Sending notification emails to: Refchange List <refchangelist@example.com>
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: Refchange List <refchangelist@example.com>
+Subject: *test-repo* branch master updated (ebf40e1 -> 902dfe1)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+Message-ID: <...>
+From: From <from@example.com>
+Reply-To: pushuser@example.com
+Thread-Index: <...>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: name<with>special&chars;.git
+X-Git-Refname: refs/heads/master
+X-Git-Reftype: branch
+X-Git-Oldrev: ebf40e1fe61e9b74334f80b1e8af506a36ddb57f
+X-Git-Newrev: 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
+X-Git-NotificationType: ref_changed
+X-Git-Multimail-Version: ...
+Auto-Submitted: auto-generated
+
+This is an automated email from the git hooks/post-receive script.
+
+pushuser pushed a change to branch master
+in repository name<with>special&chars;.git.
+
+    from ebf40e1  a4
+     add f0e9a98  f1
+     add c742b15  f2
+     add abb8baa  f3
+     new d245c99  m1
+     new 902dfe1  a5
+
+The 2 revisions listed above as "new" are entirely new to this
+repository and will be described in separate emails.  The revisions
+listed as "add" were already present in the repository and have only
+been added to this reference.
+
+
+Summary of changes:
+ a.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+<br />
+<span style="color:#808080">-- <br />
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com> or <a href="http://example.com">click here</a>.
+</span>
+EOF
+######################################################################
+######################################################################
+/usr/sbin/sendmail -oi -t -f Sender <sender@example.com> <<EOF
+Date: ...
+To: Commit List <commitlist@example.com>
+Subject: *test-repo* 02/02: a5
+MIME-Version: 1.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+From: From <from@example.com>
+Reply-To: Joe User <user@example.com>
+In-Reply-To: <...>
+References: <...>
+Thread-Index: <...>
+X-Git-Host: fqdn.example.org
+X-Git-Repo: name<with>special&chars;.git
+X-Git-Refname: refs/heads/master
+X-Git-Reftype: branch
+X-Git-Rev: 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
+X-Git-NotificationType: diff
+X-Git-Multimail-Version: ...
+Auto-Submitted: auto-generated
+X-Git-Parents: d245c99162aff6fff4879e5d5c17d454766b45db
+
+<span style="color:#808080">This is an automated email from the git hooks/post-receive script.</span><br /><br />
+
+<strong>pushuser</strong> pushed a commit to branch master
+in repository name<with>special&chars;.git.<br />
+
+<a href="https://github.com/git-multimail/git-multimail/commit/902dfe1c4025851d6b175c8f1efeee9ee1a0b74d">View on GitHub</a>.
+
+commit 902dfe1c4025851d6b175c8f1efeee9ee1a0b74d
+Author: Joe User <user@example.com>
+AuthorDate: Fri Feb 3 09:32:50 2012 +0100
+
+    a5
+---
+ a.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/a.txt b/a.txt
+index 63a911f..7ed6ff8 100644
+--- a/a.txt
++++ b/a.txt
+@@ -1 +1 @@
+-m1
++5
+<br />
+<span style="color:#808080">-- <br />
+To stop receiving notification emails like this one, please contact
+Administrator <administrator@example.com> or <a href="http://example.com">click here</a>.
+</span>
+EOF
+######################################################################

--- a/t/email-content.t
+++ b/t/email-content.t
@@ -89,6 +89,12 @@ test_email_content 'To/From/Reply-to headers' headers-specific '
 		-c multimailhook.from=from-config@example.com
 '
 
+test_email_content 'excludeMergeRevisions' ignoremerges '
+	MULTIMAIL=$SHARNESS_TEST_DIRECTORY/test_templates.py &&
+	test_update refs/heads/master refs/heads/master^^ \
+		-c multimailhook.excludeMergeRevisions=true
+'
+
 test_email_content 'emailPrefix' emailprefix '
 	verbose_do test_update refs/heads/master refs/heads/master^^ \
 		-c multimailhook.emailPrefix="XXX{%(repo_shortname)s}YYY<%(repo_shortname)s>ZZZ" &&

--- a/t/test_templates.py
+++ b/t/test_templates.py
@@ -34,5 +34,6 @@ To stop receiving notification emails like this one, please contact
 git_multimail.REVISION_FOOTER_TEMPLATE = git_multimail.FOOTER_TEMPLATE
 git_multimail.COMBINED_FOOTER_TEMPLATE = git_multimail.FOOTER_TEMPLATE
 
+git_multimail.REVISION_HEADER_TEMPLATE += "X-Git-Parents: %(parents)s\n"
 
 git_multimail.main(sys.argv[1:])


### PR DESCRIPTION
We switched to using git-multimail for sending mail to
git-commits-head@vger.kernel.org, but in the process found out that
there was no way to filter out merge commits, which kernel developers
don't want to see on that mailing list. This change introduces another
config variable called excludeMergeRevisions, which achieves the
functionality we needed.

Additionally, this adds the "parents" info to the values that can be
expanded in the templates.

Signed-off-by: Konstantin Ryabitsev <konstantin@linuxfoundation.org>