### PR TITLE
Fix compatibility with Python 3.5+ for GitoliteEnvironmentLowPrecMixin

### DIFF
--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -3264,7 +3264,10 @@ class GitoliteEnvironmentLowPrecMixin(
                 mailaddress_map = os.path.join(os.path.dirname(GL_CONF),
                                                mailaddress_map)
                 if os.path.isfile(mailaddress_map):
-                    f = open(mailaddress_map, 'rU')
+                    if sys.version_info >= (3,4):
+                        f = open(mailaddress_map, 'r')
+                    else:
+                        f = open(mailaddress_map, 'rU')
                     try:
                         # Leading '#' is optional
                         re_begin, re_user, re_end = self._compile_regex(
@@ -3288,7 +3291,10 @@ class GitoliteEnvironmentLowPrecMixin(
                         f.close()
 
             if os.path.isfile(GL_CONF):
-                f = open(GL_CONF, 'rU')
+                if sys.version_info >= (3,4):
+                    f = open(GL_CONF, 'r')
+                else:
+                    f = open(GL_CONF, 'rU')
                 try:
                     in_user_emails_section = False
                     re_begin, re_user, re_end = self._compile_regex(


### PR DESCRIPTION
In Python 3.0 'Universal Newline Mode' was marked as "for backwards compatibility; unneeded for new code"

In Python version 3.4 “universal newlines mode” was deprecated because universal newline mode is default since at least 3.0 so 'U' was removed in Python 3.7.

https://docs.python.org/3.7/library/functions.html#open

This patch makes git-multimail usable with python 3.7 and above.

This is a fix for #230 