### PR TITLE
Add option to use gitea repo user name

### DIFF
--- a/git-multimail/README.rst
+++ b/git-multimail/README.rst
@@ -197,6 +197,9 @@ multimailhook.environment
     gitea
       Environment to use when ``git-multimail`` is ran as Gitea_ or
       Forgejo_ ``post-receive`` hook.
+      
+      The ``%(repo_user_name)s`` placeholder is available to obtain
+      the Forgejo or Gitea organization or user name of the repository.
 
       This environment is detected automatically, and so doesn't need
       to be explicitly specified, normally. Just copy, or link,

--- a/git-multimail/git_multimail.py
+++ b/git-multimail/git_multimail.py
@@ -3425,11 +3425,19 @@ class GerritEnvironmentLowPrecMixin(Environment):
 
 
 class GiteaEnvironmentHighPrecMixin(Environment):
+
+    def __init__(self, **kw):
+        super(GiteaEnvironmentHighPrecMixin, self).__init__(**kw)
+        self.COMPUTED_KEYS += ['repo_user_name']
+
     def get_pusher(self):
         return self.osenv.get('GITEA_PUSHER_NAME', 'unknown user')
 
     def get_pusher_email(self):
         return self.osenv.get('GITEA_PUSHER_EMAIL')
+
+    def get_repo_user_name(self):
+        return self.osenv.get('GITEA_REPO_USER_NAME')
 
 
 class GiteaEnvironmentLowPrecMixin(Environment):


### PR DESCRIPTION
This pull request introduces the `repo_user_name` key to access the `GITEA_REPO_USER_NAME` environment variable. This is used for creating the `commitBrowseURL` when deployed across multiple organizations or users.   

Example: 
```gitconfig 
[multimailhook]
     ...
     commitBrowseURL = "https://example.org/%(repo_user_name)s/%(repo_shortname)s/commit/%(id)s"
     ...
```